### PR TITLE
internal/mapper/oas: Omit empty descriptions and false sensitive values from generated specification

### DIFF
--- a/internal/cmd/testdata/edgecase/generated_framework_ir.json
+++ b/internal/cmd/testdata/edgecase/generated_framework_ir.json
@@ -31,8 +31,7 @@
 										"name": "string_prop",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "String inside a map!",
-											"sensitive": false
+											"description": "String inside a map!"
 										}
 									}
 								]
@@ -152,8 +151,7 @@
 										"name": "string_prop",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "String inside a set!",
-											"sensitive": false
+											"description": "String inside a set!"
 										}
 									}
 								]
@@ -200,8 +198,7 @@
 										"name": "string_prop",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "String inside a map!",
-											"sensitive": false
+											"description": "String inside a map!"
 										}
 									}
 								]
@@ -243,8 +240,7 @@
 										"name": "string_prop",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "String inside a set!",
-											"sensitive": false
+											"description": "String inside a set!"
 										}
 									}
 								]

--- a/internal/cmd/testdata/github/generated_framework_ir.json
+++ b/internal/cmd/testdata/github/generated_framework_ir.json
@@ -8,58 +8,50 @@
 						"name": "owner",
 						"string": {
 							"computed_optional_required": "required",
-							"description": "The account owner of the repository. The name is not case sensitive.",
-							"sensitive": false
+							"description": "The account owner of the repository. The name is not case sensitive."
 						}
 					},
 					{
 						"name": "repo",
 						"string": {
 							"computed_optional_required": "required",
-							"description": "The name of the repository. The name is not case sensitive.",
-							"sensitive": false
+							"description": "The name of the repository. The name is not case sensitive."
 						}
 					},
 					{
 						"name": "allow_auto_merge",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "allow_forking",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "allow_merge_commit",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "allow_rebase_merge",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "allow_squash_merge",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "allow_update_branch",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -72,48 +64,37 @@
 					{
 						"name": "archive_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "archived",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "assignees_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "blobs_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "branches_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "clone_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -124,33 +105,25 @@
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "key",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -160,88 +133,67 @@
 					{
 						"name": "collaborators_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "comments_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "commits_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "compare_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "contents_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "contributors_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "created_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "default_branch",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "delete_branch_on_merge",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "deployments_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "description",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -254,222 +206,175 @@
 					{
 						"name": "downloads_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "events_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "fork",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "forks",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "forks_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "forks_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "full_name",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_commits_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_refs_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_tags_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_discussions",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_downloads",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_issues",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_pages",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_projects",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_wiki",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "homepage",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "hooks_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "html_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "id",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "is_template",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "issue_comment_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "issue_events_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "issues_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "keys_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "labels_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "language",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "languages_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -480,49 +385,37 @@
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "key",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "spdx_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -532,9 +425,7 @@
 					{
 						"name": "master_branch",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -542,7 +433,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -562,7 +452,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a merge commit title.\n\n  - `PR_TITLE` - default to the pull request's title.\n  - `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -580,70 +469,55 @@
 					{
 						"name": "merges_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "milestones_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "mirror_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "name",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "network_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "node_id",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "notifications_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "open_issues",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "open_issues_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -654,167 +528,127 @@
 								{
 									"name": "avatar_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "email",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "followers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "following_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "gists_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "gravatar_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "id",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "login",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "organizations_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "received_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "repos_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "site_admin",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscriptions_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "type",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -878,9 +712,7 @@
 								{
 									"name": "archive_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -893,97 +725,74 @@
 								{
 									"name": "assignees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "blobs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "branches_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "clone_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "collaborators_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "comments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "compare_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contents_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contributors_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "created_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "default_branch",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The default branch of the repository.",
-										"sensitive": false
+										"description": "The default branch of the repository."
 									}
 								},
 								{
@@ -996,17 +805,13 @@
 								{
 									"name": "deployments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "description",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1019,86 +824,67 @@
 								{
 									"name": "downloads_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "fork",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "full_name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_refs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1125,8 +911,7 @@
 								{
 									"name": "has_pages",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1146,25 +931,19 @@
 								{
 									"name": "homepage",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "hooks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1184,57 +963,43 @@
 								{
 									"name": "issue_comment_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issues_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "keys_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "labels_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "language",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "languages_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1245,49 +1010,37 @@
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "key",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "spdx_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -1297,9 +1050,7 @@
 								{
 									"name": "master_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1307,7 +1058,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -1327,7 +1077,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -1345,70 +1094,56 @@
 								{
 									"name": "merges_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "milestones_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "mirror_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The name of the repository.",
-										"sensitive": false
+										"description": "The name of the repository."
 									}
 								},
 								{
 									"name": "network_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "notifications_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1419,167 +1154,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -1594,167 +1289,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -1769,40 +1424,34 @@
 											{
 												"name": "admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "maintain",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pull",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "push",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "triage",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -1815,25 +1464,19 @@
 								{
 									"name": "pulls_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pushed_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "releases_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1848,7 +1491,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -1868,7 +1510,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -1886,95 +1527,73 @@
 								{
 									"name": "ssh_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "statuses_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscription_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "svn_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "teams_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "temp_clone_token",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -1985,384 +1604,301 @@
 											{
 												"name": "allow_auto_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_merge_commit",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_rebase_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_squash_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_update_branch",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archive_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archived",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "assignees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "blobs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "branches_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "clone_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "collaborators_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "comments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "compare_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contents_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contributors_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "created_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "default_branch",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "delete_branch_on_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "deployments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "description",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "disabled",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "downloads_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "fork",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "full_name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_refs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_downloads",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_issues",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_pages",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_projects",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_wiki",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "homepage",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hooks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "is_template",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_comment_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issues_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "keys_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "labels_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "language",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "languages_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -2370,7 +1906,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -2390,7 +1925,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -2408,63 +1942,49 @@
 											{
 												"name": "merges_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "milestones_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "mirror_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "network_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "notifications_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "open_issues_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -2475,147 +1995,112 @@
 														{
 															"name": "avatar_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "followers_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "following_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gists_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gravatar_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "html_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"int64": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "login",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "node_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organizations_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "received_events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "repos_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "site_admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "starred_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "subscriptions_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "type",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -2626,78 +2111,64 @@
 														{
 															"name": "admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "maintain",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "pull",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "push",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "triage",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "private",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pulls_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pushed_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "releases_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "size",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -2705,7 +2176,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -2725,7 +2195,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -2743,87 +2212,67 @@
 											{
 												"name": "ssh_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "statuses_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscription_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "svn_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "teams_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "temp_clone_token",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -2832,58 +2281,46 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "trees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "updated_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "use_squash_pr_title_as_default",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "visibility",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "watchers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -2892,32 +2329,25 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "trees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "updated_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -2931,22 +2361,19 @@
 									"name": "visibility",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The repository visibility: public, private, or internal.",
-										"sensitive": false
+										"description": "The repository visibility: public, private, or internal."
 									}
 								},
 								{
 									"name": "watchers",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "watchers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -2968,71 +2395,58 @@
 								{
 									"name": "admin",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "maintain",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pull",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "push",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "triage",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
 						"name": "private",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "pulls_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "pushed_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "releases_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -3049,8 +2463,6 @@
 												"name": "status",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -3065,8 +2477,7 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -3078,8 +2489,6 @@
 												"name": "status",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -3094,8 +2503,7 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -3107,8 +2515,6 @@
 												"name": "status",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -3123,12 +2529,10 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
@@ -3195,9 +2599,7 @@
 								{
 									"name": "archive_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3210,97 +2612,74 @@
 								{
 									"name": "assignees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "blobs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "branches_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "clone_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "collaborators_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "comments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "compare_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contents_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contributors_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "created_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "default_branch",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The default branch of the repository.",
-										"sensitive": false
+										"description": "The default branch of the repository."
 									}
 								},
 								{
@@ -3313,17 +2692,13 @@
 								{
 									"name": "deployments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "description",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3336,86 +2711,67 @@
 								{
 									"name": "downloads_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "fork",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "full_name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_refs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3442,8 +2798,7 @@
 								{
 									"name": "has_pages",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3463,25 +2818,19 @@
 								{
 									"name": "homepage",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "hooks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3501,57 +2850,43 @@
 								{
 									"name": "issue_comment_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issues_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "keys_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "labels_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "language",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "languages_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3562,49 +2897,37 @@
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "key",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "spdx_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -3614,9 +2937,7 @@
 								{
 									"name": "master_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3624,7 +2945,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -3644,7 +2964,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -3662,70 +2981,56 @@
 								{
 									"name": "merges_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "milestones_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "mirror_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The name of the repository.",
-										"sensitive": false
+										"description": "The name of the repository."
 									}
 								},
 								{
 									"name": "network_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "notifications_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3736,167 +3041,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -3911,167 +3176,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -4086,40 +3311,34 @@
 											{
 												"name": "admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "maintain",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pull",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "push",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "triage",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -4132,25 +3351,19 @@
 								{
 									"name": "pulls_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pushed_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "releases_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -4165,7 +3378,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -4185,7 +3397,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -4203,95 +3414,73 @@
 								{
 									"name": "ssh_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "statuses_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscription_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "svn_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "teams_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "temp_clone_token",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -4302,384 +3491,301 @@
 											{
 												"name": "allow_auto_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_merge_commit",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_rebase_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_squash_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_update_branch",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archive_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archived",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "assignees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "blobs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "branches_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "clone_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "collaborators_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "comments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "compare_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contents_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contributors_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "created_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "default_branch",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "delete_branch_on_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "deployments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "description",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "disabled",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "downloads_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "fork",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "full_name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_refs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_downloads",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_issues",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_pages",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_projects",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_wiki",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "homepage",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hooks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "is_template",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_comment_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issues_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "keys_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "labels_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "language",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "languages_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -4687,7 +3793,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -4707,7 +3812,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -4725,63 +3829,49 @@
 											{
 												"name": "merges_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "milestones_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "mirror_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "network_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "notifications_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "open_issues_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -4792,147 +3882,112 @@
 														{
 															"name": "avatar_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "followers_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "following_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gists_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gravatar_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "html_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"int64": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "login",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "node_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organizations_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "received_events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "repos_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "site_admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "starred_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "subscriptions_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "type",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -4943,78 +3998,64 @@
 														{
 															"name": "admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "maintain",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "pull",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "push",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "triage",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "private",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pulls_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pushed_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "releases_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "size",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -5022,7 +4063,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -5042,7 +4082,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -5060,87 +4099,67 @@
 											{
 												"name": "ssh_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "statuses_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscription_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "svn_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "teams_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "temp_clone_token",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -5149,58 +4168,46 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "trees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "updated_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "use_squash_pr_title_as_default",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "visibility",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "watchers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -5209,32 +4216,25 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "trees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "updated_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5248,22 +4248,19 @@
 									"name": "visibility",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The repository visibility: public, private, or internal.",
-										"sensitive": false
+										"description": "The repository visibility: public, private, or internal."
 									}
 								},
 								{
 									"name": "watchers",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "watchers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5282,7 +4279,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -5302,7 +4298,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -5320,87 +4315,67 @@
 					{
 						"name": "ssh_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "stargazers_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "stargazers_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "statuses_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "subscribers_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "subscribers_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "subscription_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "svn_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "tags_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "teams_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "temp_clone_token",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -5460,9 +4435,7 @@
 								{
 									"name": "archive_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5475,97 +4448,74 @@
 								{
 									"name": "assignees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "blobs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "branches_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "clone_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "collaborators_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "comments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "compare_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contents_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contributors_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "created_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "default_branch",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The default branch of the repository.",
-										"sensitive": false
+										"description": "The default branch of the repository."
 									}
 								},
 								{
@@ -5578,17 +4528,13 @@
 								{
 									"name": "deployments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "description",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5601,86 +4547,67 @@
 								{
 									"name": "downloads_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "fork",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "full_name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_refs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5707,8 +4634,7 @@
 								{
 									"name": "has_pages",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5728,25 +4654,19 @@
 								{
 									"name": "homepage",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "hooks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5766,57 +4686,43 @@
 								{
 									"name": "issue_comment_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issues_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "keys_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "labels_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "language",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "languages_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5827,49 +4733,37 @@
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "key",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "spdx_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -5879,9 +4773,7 @@
 								{
 									"name": "master_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -5889,7 +4781,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -5909,7 +4800,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -5927,70 +4817,56 @@
 								{
 									"name": "merges_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "milestones_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "mirror_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The name of the repository.",
-										"sensitive": false
+										"description": "The name of the repository."
 									}
 								},
 								{
 									"name": "network_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "notifications_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -6001,167 +4877,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -6176,167 +5012,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -6351,40 +5147,34 @@
 											{
 												"name": "admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "maintain",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pull",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "push",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "triage",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -6397,25 +5187,19 @@
 								{
 									"name": "pulls_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pushed_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "releases_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -6430,7 +5214,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -6450,7 +5233,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -6468,95 +5250,73 @@
 								{
 									"name": "ssh_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "statuses_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscription_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "svn_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "teams_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "temp_clone_token",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -6567,384 +5327,301 @@
 											{
 												"name": "allow_auto_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_merge_commit",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_rebase_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_squash_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_update_branch",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archive_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archived",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "assignees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "blobs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "branches_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "clone_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "collaborators_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "comments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "compare_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contents_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contributors_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "created_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "default_branch",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "delete_branch_on_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "deployments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "description",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "disabled",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "downloads_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "fork",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "full_name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_refs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_downloads",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_issues",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_pages",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_projects",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_wiki",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "homepage",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hooks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "is_template",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_comment_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issues_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "keys_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "labels_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "language",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "languages_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -6952,7 +5629,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -6972,7 +5648,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -6990,63 +5665,49 @@
 											{
 												"name": "merges_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "milestones_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "mirror_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "network_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "notifications_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "open_issues_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -7057,147 +5718,112 @@
 														{
 															"name": "avatar_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "followers_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "following_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gists_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gravatar_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "html_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"int64": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "login",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "node_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organizations_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "received_events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "repos_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "site_admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "starred_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "subscriptions_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "type",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -7208,78 +5834,64 @@
 														{
 															"name": "admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "maintain",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "pull",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "push",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "triage",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "private",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pulls_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pushed_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "releases_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "size",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -7287,7 +5899,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -7307,7 +5918,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -7325,87 +5935,67 @@
 											{
 												"name": "ssh_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "statuses_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscription_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "svn_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "teams_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "temp_clone_token",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -7414,58 +6004,46 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "trees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "updated_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "use_squash_pr_title_as_default",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "visibility",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "watchers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -7474,32 +6052,25 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "trees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "updated_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -7513,22 +6084,19 @@
 									"name": "visibility",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The repository visibility: public, private, or internal.",
-										"sensitive": false
+										"description": "The repository visibility: public, private, or internal."
 									}
 								},
 								{
 									"name": "watchers",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "watchers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -7548,68 +6116,56 @@
 							"computed_optional_required": "computed_optional",
 							"element_type": {
 								"string": {}
-							},
-							"description": ""
+							}
 						}
 					},
 					{
 						"name": "trees_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "updated_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "use_squash_pr_title_as_default",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "visibility",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The repository visibility: public, private, or internal.",
-							"sensitive": false
+							"description": "The repository visibility: public, private, or internal."
 						}
 					},
 					{
 						"name": "watchers",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "watchers_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "web_commit_signoff_required",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					}
 				]
@@ -7670,16 +6226,14 @@
 						"name": "description",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "A short description of the repository.",
-							"sensitive": false
+							"description": "A short description of the repository."
 						}
 					},
 					{
 						"name": "gitignore_template",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The desired language or platform to apply to the .gitignore.",
-							"sensitive": false
+							"description": "The desired language or platform to apply to the .gitignore."
 						}
 					},
 					{
@@ -7721,8 +6275,7 @@
 						"name": "homepage",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "A URL with more information about the repository.",
-							"sensitive": false
+							"description": "A URL with more information about the repository."
 						}
 					},
 					{
@@ -7736,8 +6289,7 @@
 						"name": "license_template",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The license keyword of the open source license for this repository.",
-							"sensitive": false
+							"description": "The license keyword of the open source license for this repository."
 						}
 					},
 					{
@@ -7745,7 +6297,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -7765,7 +6316,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -7784,8 +6334,7 @@
 						"name": "name",
 						"string": {
 							"computed_optional_required": "required",
-							"description": "The name of the repository.",
-							"sensitive": false
+							"description": "The name of the repository."
 						}
 					},
 					{
@@ -7800,7 +6349,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -7820,7 +6368,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -7866,9 +6413,7 @@
 					{
 						"name": "archive_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -7881,105 +6426,80 @@
 					{
 						"name": "assignees_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "blobs_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "branches_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "clone_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "collaborators_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "comments_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "commits_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "compare_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "contents_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "contributors_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "created_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "default_branch",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The default branch of the repository.",
-							"sensitive": false
+							"description": "The default branch of the repository."
 						}
 					},
 					{
 						"name": "deployments_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -7992,109 +6512,85 @@
 					{
 						"name": "downloads_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "events_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "fork",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "forks",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "forks_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "forks_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "full_name",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_commits_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_refs_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_tags_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "git_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "has_pages",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "hooks_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "html_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -8107,57 +6603,43 @@
 					{
 						"name": "issue_comment_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "issue_events_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "issues_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "keys_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "labels_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "language",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "languages_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -8168,49 +6650,37 @@
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "key",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "spdx_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -8220,70 +6690,55 @@
 					{
 						"name": "master_branch",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "merges_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "milestones_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "mirror_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "network_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "node_id",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "notifications_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "open_issues",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "open_issues_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -8294,167 +6749,127 @@
 								{
 									"name": "avatar_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "email",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "followers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "following_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "gists_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "gravatar_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "id",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "login",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "organizations_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "received_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "repos_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "site_admin",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscriptions_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "type",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -8469,167 +6884,127 @@
 								{
 									"name": "avatar_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "email",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "followers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "following_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "gists_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "gravatar_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "id",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "login",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "organizations_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "received_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "repos_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "site_admin",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscriptions_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "type",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -8644,64 +7019,52 @@
 								{
 									"name": "admin",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "maintain",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pull",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "push",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "triage",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
 						"name": "pulls_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "pushed_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "releases_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -8714,95 +7077,73 @@
 					{
 						"name": "ssh_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "stargazers_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "stargazers_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "starred_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "statuses_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "subscribers_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "subscribers_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "subscription_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "svn_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "tags_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "teams_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "temp_clone_token",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -8813,384 +7154,301 @@
 								{
 									"name": "allow_auto_merge",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "allow_merge_commit",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "allow_rebase_merge",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "allow_squash_merge",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "allow_update_branch",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "archive_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "archived",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "assignees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "blobs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "branches_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "clone_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "collaborators_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "comments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "compare_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contents_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contributors_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "created_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "default_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "delete_branch_on_merge",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "deployments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "description",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "disabled",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "downloads_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "fork",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "full_name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_refs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "has_downloads",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "has_issues",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "has_pages",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "has_projects",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "has_wiki",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "homepage",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "hooks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "id",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "is_template",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_comment_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issues_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "keys_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "labels_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "language",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "languages_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9198,7 +7456,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -9218,7 +7475,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -9236,63 +7492,49 @@
 								{
 									"name": "merges_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "milestones_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "mirror_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "network_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "notifications_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9303,171 +7545,130 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -9478,78 +7679,64 @@
 											{
 												"name": "admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "maintain",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pull",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "push",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "triage",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
 									"name": "private",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pulls_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pushed_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "releases_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "size",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9557,7 +7744,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -9577,7 +7763,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -9595,87 +7780,67 @@
 								{
 									"name": "ssh_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "statuses_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscription_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "svn_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "teams_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "temp_clone_token",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9684,54 +7849,43 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "trees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "updated_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "use_squash_pr_title_as_default",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "visibility",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "watchers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9751,8 +7905,7 @@
 								{
 									"name": "forks",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9770,49 +7923,37 @@
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "key",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "spdx_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -9822,16 +7963,13 @@
 								{
 									"name": "master_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -9842,167 +7980,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -10012,9 +8110,7 @@
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -10025,384 +8121,301 @@
 											{
 												"name": "allow_auto_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_merge_commit",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_rebase_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_squash_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_update_branch",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archive_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archived",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "assignees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "blobs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "branches_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "clone_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "collaborators_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "comments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "compare_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contents_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contributors_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "created_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "default_branch",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "delete_branch_on_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "deployments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "description",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "disabled",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "downloads_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "fork",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "full_name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_refs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_downloads",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_issues",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_pages",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_projects",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_wiki",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "homepage",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hooks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "is_template",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_comment_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issues_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "keys_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "labels_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "language",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "languages_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -10410,7 +8423,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -10430,7 +8442,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -10448,63 +8459,49 @@
 											{
 												"name": "merges_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "milestones_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "mirror_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "network_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "notifications_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "open_issues_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -10515,147 +8512,112 @@
 														{
 															"name": "avatar_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "followers_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "following_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gists_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gravatar_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "html_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"int64": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "login",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "node_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organizations_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "received_events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "repos_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "site_admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "starred_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "subscriptions_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "type",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -10666,78 +8628,64 @@
 														{
 															"name": "admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "maintain",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "pull",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "push",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "triage",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "private",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pulls_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pushed_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "releases_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "size",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -10745,7 +8693,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -10765,7 +8712,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -10783,87 +8729,67 @@
 											{
 												"name": "ssh_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "statuses_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscription_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "svn_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "teams_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "temp_clone_token",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -10872,65 +8798,52 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "trees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "updated_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "use_squash_pr_title_as_default",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "visibility",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "watchers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
 									"name": "watchers",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -10940,8 +8853,7 @@
 										"description": "Whether to require contributors to sign off on web-based commits"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
@@ -10950,32 +8862,25 @@
 							"computed_optional_required": "computed_optional",
 							"element_type": {
 								"string": {}
-							},
-							"description": ""
+							}
 						}
 					},
 					{
 						"name": "trees_url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "updated_at",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "url",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -10989,22 +8894,19 @@
 						"name": "visibility",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The repository visibility: public, private, or internal.",
-							"sensitive": false
+							"description": "The repository visibility: public, private, or internal."
 						}
 					},
 					{
 						"name": "watchers",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "watchers_count",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -11022,33 +8924,25 @@
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "key",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
 							],
@@ -11112,9 +9006,7 @@
 								{
 									"name": "archive_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11127,97 +9019,74 @@
 								{
 									"name": "assignees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "blobs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "branches_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "clone_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "collaborators_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "comments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "compare_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contents_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contributors_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "created_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "default_branch",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The default branch of the repository.",
-										"sensitive": false
+										"description": "The default branch of the repository."
 									}
 								},
 								{
@@ -11230,17 +9099,13 @@
 								{
 									"name": "deployments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "description",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11253,86 +9118,67 @@
 								{
 									"name": "downloads_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "fork",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "full_name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_refs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11359,8 +9205,7 @@
 								{
 									"name": "has_pages",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11380,25 +9225,19 @@
 								{
 									"name": "homepage",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "hooks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11418,57 +9257,43 @@
 								{
 									"name": "issue_comment_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issues_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "keys_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "labels_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "language",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "languages_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11479,49 +9304,37 @@
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "key",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "spdx_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -11531,9 +9344,7 @@
 								{
 									"name": "master_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11541,7 +9352,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -11561,7 +9371,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -11579,70 +9388,56 @@
 								{
 									"name": "merges_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "milestones_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "mirror_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The name of the repository.",
-										"sensitive": false
+										"description": "The name of the repository."
 									}
 								},
 								{
 									"name": "network_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "notifications_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -11653,167 +9448,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -11828,167 +9583,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -12003,40 +9718,34 @@
 											{
 												"name": "admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "maintain",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pull",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "push",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "triage",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -12049,25 +9758,19 @@
 								{
 									"name": "pulls_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pushed_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "releases_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -12082,7 +9785,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -12102,7 +9804,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -12120,95 +9821,73 @@
 								{
 									"name": "ssh_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "statuses_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscription_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "svn_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "teams_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "temp_clone_token",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -12219,384 +9898,301 @@
 											{
 												"name": "allow_auto_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_merge_commit",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_rebase_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_squash_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_update_branch",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archive_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archived",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "assignees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "blobs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "branches_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "clone_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "collaborators_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "comments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "compare_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contents_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contributors_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "created_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "default_branch",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "delete_branch_on_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "deployments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "description",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "disabled",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "downloads_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "fork",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "full_name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_refs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_downloads",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_issues",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_pages",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_projects",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_wiki",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "homepage",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hooks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "is_template",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_comment_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issues_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "keys_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "labels_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "language",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "languages_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -12604,7 +10200,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -12624,7 +10219,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -12642,63 +10236,49 @@
 											{
 												"name": "merges_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "milestones_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "mirror_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "network_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "notifications_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "open_issues_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -12709,147 +10289,112 @@
 														{
 															"name": "avatar_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "followers_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "following_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gists_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gravatar_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "html_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"int64": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "login",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "node_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organizations_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "received_events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "repos_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "site_admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "starred_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "subscriptions_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "type",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -12860,78 +10405,64 @@
 														{
 															"name": "admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "maintain",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "pull",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "push",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "triage",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "private",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pulls_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pushed_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "releases_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "size",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -12939,7 +10470,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -12959,7 +10489,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -12977,87 +10506,67 @@
 											{
 												"name": "ssh_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "statuses_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscription_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "svn_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "teams_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "temp_clone_token",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -13066,58 +10575,46 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "trees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "updated_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "use_squash_pr_title_as_default",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "visibility",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "watchers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -13126,32 +10623,25 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "trees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "updated_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13165,22 +10655,19 @@
 									"name": "visibility",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The repository visibility: public, private, or internal.",
-										"sensitive": false
+										"description": "The repository visibility: public, private, or internal."
 									}
 								},
 								{
 									"name": "watchers",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "watchers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13208,8 +10695,6 @@
 												"name": "status",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -13224,8 +10709,7 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -13237,8 +10721,6 @@
 												"name": "status",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -13253,8 +10735,7 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -13266,8 +10747,6 @@
 												"name": "status",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -13282,12 +10761,10 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
@@ -13347,9 +10824,7 @@
 								{
 									"name": "archive_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13362,97 +10837,74 @@
 								{
 									"name": "assignees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "blobs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "branches_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "clone_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "collaborators_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "comments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "compare_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contents_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "contributors_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "created_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "default_branch",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The default branch of the repository.",
-										"sensitive": false
+										"description": "The default branch of the repository."
 									}
 								},
 								{
@@ -13465,17 +10917,13 @@
 								{
 									"name": "deployments_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "description",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13488,86 +10936,67 @@
 								{
 									"name": "downloads_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "fork",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "forks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "full_name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_commits_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_refs_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "git_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13594,8 +11023,7 @@
 								{
 									"name": "has_pages",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13615,25 +11043,19 @@
 								{
 									"name": "homepage",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "hooks_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "html_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13653,57 +11075,43 @@
 								{
 									"name": "issue_comment_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issue_events_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "issues_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "keys_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "labels_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "language",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "languages_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13714,49 +11122,37 @@
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "key",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "spdx_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -13766,9 +11162,7 @@
 								{
 									"name": "master_branch",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13776,7 +11170,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -13796,7 +11189,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -13814,70 +11206,56 @@
 								{
 									"name": "merges_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "milestones_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "mirror_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The name of the repository.",
-										"sensitive": false
+										"description": "The name of the repository."
 									}
 								},
 								{
 									"name": "network_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "node_id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "notifications_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "open_issues_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -13888,167 +11266,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -14063,167 +11401,127 @@
 											{
 												"name": "avatar_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "email",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "followers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "following_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gists_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "gravatar_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "login",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organizations_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "received_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "repos_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "site_admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "starred_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscriptions_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "type",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -14238,40 +11536,34 @@
 											{
 												"name": "admin",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "maintain",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pull",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "push",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "triage",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -14284,25 +11576,19 @@
 								{
 									"name": "pulls_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "pushed_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "releases_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -14317,7 +11603,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -14337,7 +11622,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -14355,95 +11639,73 @@
 								{
 									"name": "ssh_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "stargazers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "starred_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "statuses_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscribers_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "subscription_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "svn_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "tags_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "teams_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "temp_clone_token",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -14454,384 +11716,301 @@
 											{
 												"name": "allow_auto_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_merge_commit",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_rebase_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_squash_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "allow_update_branch",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archive_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "archived",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "assignees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "blobs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "branches_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "clone_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "collaborators_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "comments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "compare_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contents_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "contributors_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "created_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "default_branch",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "delete_branch_on_merge",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "deployments_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "description",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "disabled",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "downloads_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "fork",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "forks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "full_name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_commits_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_refs_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "git_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_downloads",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_issues",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_pages",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_projects",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "has_wiki",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "homepage",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hooks_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "html_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "is_template",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_comment_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issue_events_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "issues_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "keys_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "labels_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "language",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "languages_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -14839,7 +12018,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit message.\n\n- `PR_TITLE` - default to the pull request's title.\n- `PR_BODY` - default to the pull request's body.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -14859,7 +12037,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a merge commit title.\n\n- `PR_TITLE` - default to the pull request's title.\n- `MERGE_MESSAGE` - default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -14877,63 +12054,49 @@
 											{
 												"name": "merges_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "milestones_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "mirror_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "network_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "notifications_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "open_issues_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -14944,147 +12107,112 @@
 														{
 															"name": "avatar_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "followers_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "following_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gists_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "gravatar_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "html_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"int64": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "login",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "node_id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organizations_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "received_events_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "repos_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "site_admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "starred_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "subscriptions_url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "type",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "url",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -15095,78 +12223,64 @@
 														{
 															"name": "admin",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "maintain",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "pull",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "push",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "triage",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "private",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pulls_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "pushed_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "releases_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "size",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -15174,7 +12288,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit message:\n\n- `PR_BODY` - default to the pull request's body.\n- `COMMIT_MESSAGES` - default to the branch's commit messages.\n- `BLANK` - default to a blank commit message.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -15194,7 +12307,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The default value for a squash merge commit title:\n\n- `PR_TITLE` - default to the pull request's title.\n- `COMMIT_OR_PR_TITLE` - default to the commit's title (if only one commit) or the pull request's title (when more than one commit).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -15212,87 +12324,67 @@
 											{
 												"name": "ssh_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "stargazers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "statuses_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscribers_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "subscription_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "svn_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "tags_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "teams_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "temp_clone_token",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -15301,58 +12393,46 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "trees_url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "updated_at",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "url",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "use_squash_pr_title_as_default",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "visibility",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "watchers_count",
 												"int64": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -15361,32 +12441,25 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "trees_url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "updated_at",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "url",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -15400,22 +12473,19 @@
 									"name": "visibility",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The repository visibility: public, private, or internal.",
-										"sensitive": false
+										"description": "The repository visibility: public, private, or internal."
 									}
 								},
 								{
 									"name": "watchers",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "watchers_count",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -15433,8 +12503,7 @@
 						"name": "repo",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The name of the repository. The name is not case sensitive.",
-							"sensitive": false
+							"description": "The name of the repository. The name is not case sensitive."
 						}
 					}
 				]

--- a/internal/cmd/testdata/petstore3/generated_framework_ir.json
+++ b/internal/cmd/testdata/petstore3/generated_framework_ir.json
@@ -14,37 +14,31 @@
 					{
 						"name": "complete",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "id",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "petId",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "quantity",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "shipDate",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -52,7 +46,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "Order Status",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -89,35 +82,28 @@
 								{
 									"name": "id",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
 						"name": "id",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "name",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -126,8 +112,7 @@
 							"computed_optional_required": "computed_optional",
 							"element_type": {
 								"string": {}
-							},
-							"description": ""
+							}
 						}
 					},
 					{
@@ -135,7 +120,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "pet status in the store",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -159,21 +143,17 @@
 									{
 										"name": "id",
 										"int64": {
-											"computed_optional_required": "computed_optional",
-											"description": ""
+											"computed_optional_required": "computed_optional"
 										}
 									},
 									{
 										"name": "name",
 										"string": {
-											"computed_optional_required": "computed_optional",
-											"description": "",
-											"sensitive": false
+											"computed_optional_required": "computed_optional"
 										}
 									}
 								]
-							},
-							"description": ""
+							}
 						}
 					}
 				]
@@ -188,7 +168,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "Status values that need to be considered for filter",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -218,37 +197,31 @@
 					{
 						"name": "complete",
 						"bool": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "id",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "petId",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "quantity",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "shipDate",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -256,7 +229,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "Order Status",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -293,35 +265,28 @@
 								{
 									"name": "id",
 									"int64": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
 						"name": "id",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "name",
 						"string": {
-							"computed_optional_required": "required",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "required"
 						}
 					},
 					{
@@ -330,8 +295,7 @@
 							"computed_optional_required": "required",
 							"element_type": {
 								"string": {}
-							},
-							"description": ""
+							}
 						}
 					},
 					{
@@ -339,7 +303,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "pet status in the store",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -363,21 +326,17 @@
 									{
 										"name": "id",
 										"int64": {
-											"computed_optional_required": "required",
-											"description": ""
+											"computed_optional_required": "required"
 										}
 									},
 									{
 										"name": "name",
 										"string": {
-											"computed_optional_required": "computed_optional",
-											"description": "",
-											"sensitive": false
+											"computed_optional_required": "computed_optional"
 										}
 									}
 								]
-							},
-							"description": ""
+							}
 						}
 					},
 					{
@@ -397,48 +356,37 @@
 					{
 						"name": "email",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "firstName",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "id",
 						"int64": {
-							"computed_optional_required": "computed_optional",
-							"description": ""
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "lastName",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "password",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
 						"name": "phone",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					},
 					{
@@ -451,9 +399,7 @@
 					{
 						"name": "username",
 						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "",
-							"sensitive": false
+							"computed_optional_required": "computed_optional"
 						}
 					}
 				]

--- a/internal/cmd/testdata/scaleway/generated_framework_ir.json
+++ b/internal/cmd/testdata/scaleway/generated_framework_ir.json
@@ -9,7 +9,6 @@
 						"string": {
 							"computed_optional_required": "required",
 							"description": "The zone you want to target",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -28,8 +27,7 @@
 						"name": "server_id",
 						"string": {
 							"computed_optional_required": "required",
-							"description": "UUID of the server you want to get.",
-							"sensitive": false
+							"description": "UUID of the server you want to get."
 						}
 					},
 					{
@@ -52,7 +50,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The server arch.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -72,7 +69,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The server boot type.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -97,7 +93,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The bootscript arch.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -116,8 +111,7 @@
 												"name": "bootcmdargs",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript arguments.",
-													"sensitive": false
+													"description": "The bootscript arguments."
 												}
 											},
 											{
@@ -131,48 +125,42 @@
 												"name": "dtb",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers.",
-													"sensitive": false
+													"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers."
 												}
 											},
 											{
 												"name": "id",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript ID.",
-													"sensitive": false
+													"description": "The bootscript ID."
 												}
 											},
 											{
 												"name": "initrd",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The initrd (initial ramdisk) configuration.",
-													"sensitive": false
+													"description": "The initrd (initial ramdisk) configuration."
 												}
 											},
 											{
 												"name": "kernel",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The server kernel version.",
-													"sensitive": false
+													"description": "The server kernel version."
 												}
 											},
 											{
 												"name": "organization",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript organization ID.",
-													"sensitive": false
+													"description": "The bootscript organization ID."
 												}
 											},
 											{
 												"name": "project",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript project ID.",
-													"sensitive": false
+													"description": "The bootscript project ID."
 												}
 											},
 											{
@@ -186,16 +174,14 @@
 												"name": "title",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript title.",
-													"sensitive": false
+													"description": "The bootscript title."
 												}
 											},
 											{
 												"name": "zone",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The zone in which is the bootscript.",
-													"sensitive": false
+													"description": "The zone in which is the bootscript."
 												}
 											}
 										],
@@ -206,16 +192,14 @@
 									"name": "commercial_type",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server commercial type (eg. GP1-M).",
-										"sensitive": false
+										"description": "The server commercial type (eg. GP1-M)."
 									}
 								},
 								{
 									"name": "creation_date",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server creation date. (RFC 3339 format)",
-										"sensitive": false
+										"description": "The server creation date. (RFC 3339 format)"
 									}
 								},
 								{
@@ -236,16 +220,14 @@
 									"name": "hostname",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server host name.",
-										"sensitive": false
+										"description": "The server host name."
 									}
 								},
 								{
 									"name": "id",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server unique ID.",
-										"sensitive": false
+										"description": "The server unique ID."
 									}
 								},
 								{
@@ -257,8 +239,6 @@
 												"name": "arch",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -277,8 +257,7 @@
 												"name": "creation_date",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "(RFC 3339 format)",
-													"sensitive": false
+													"description": "(RFC 3339 format)"
 												}
 											},
 											{
@@ -291,7 +270,6 @@
 															"string": {
 																"computed_optional_required": "computed_optional",
 																"description": "The bootscript arch.",
-																"sensitive": false,
 																"validators": [
 																	{
 																		"custom": {
@@ -310,8 +288,7 @@
 															"name": "bootcmdargs",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The bootscript arguments.",
-																"sensitive": false
+																"description": "The bootscript arguments."
 															}
 														},
 														{
@@ -325,48 +302,42 @@
 															"name": "dtb",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers.",
-																"sensitive": false
+																"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers."
 															}
 														},
 														{
 															"name": "id",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The bootscript ID.",
-																"sensitive": false
+																"description": "The bootscript ID."
 															}
 														},
 														{
 															"name": "initrd",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The initrd (initial ramdisk) configuration.",
-																"sensitive": false
+																"description": "The initrd (initial ramdisk) configuration."
 															}
 														},
 														{
 															"name": "kernel",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The server kernel version.",
-																"sensitive": false
+																"description": "The server kernel version."
 															}
 														},
 														{
 															"name": "organization",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The bootscript organization ID.",
-																"sensitive": false
+																"description": "The bootscript organization ID."
 															}
 														},
 														{
 															"name": "project",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The bootscript project ID.",
-																"sensitive": false
+																"description": "The bootscript project ID."
 															}
 														},
 														{
@@ -380,20 +351,17 @@
 															"name": "title",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The bootscript title.",
-																"sensitive": false
+																"description": "The bootscript title."
 															}
 														},
 														{
 															"name": "zone",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The zone in which is the bootscript.",
-																"sensitive": false
+																"description": "The zone in which is the bootscript."
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
@@ -410,56 +378,49 @@
 																		"name": "creation_date",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The volume creation date. (RFC 3339 format)",
-																			"sensitive": false
+																			"description": "The volume creation date. (RFC 3339 format)"
 																		}
 																	},
 																	{
 																		"name": "export_uri",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "Show the volume NBD export URI.",
-																			"sensitive": false
+																			"description": "Show the volume NBD export URI."
 																		}
 																	},
 																	{
 																		"name": "id",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The volume unique ID.",
-																			"sensitive": false
+																			"description": "The volume unique ID."
 																		}
 																	},
 																	{
 																		"name": "modification_date",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The volume modification date. (RFC 3339 format)",
-																			"sensitive": false
+																			"description": "The volume modification date. (RFC 3339 format)"
 																		}
 																	},
 																	{
 																		"name": "name",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The volume name.",
-																			"sensitive": false
+																			"description": "The volume name."
 																		}
 																	},
 																	{
 																		"name": "organization",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The volume organization ID.",
-																			"sensitive": false
+																			"description": "The volume organization ID."
 																		}
 																	},
 																	{
 																		"name": "project",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The volume project ID.",
-																			"sensitive": false
+																			"description": "The volume project ID."
 																		}
 																	},
 																	{
@@ -470,17 +431,13 @@
 																				{
 																					"name": "id",
 																					"string": {
-																						"computed_optional_required": "computed_optional",
-																						"description": "",
-																						"sensitive": false
+																						"computed_optional_required": "computed_optional"
 																					}
 																				},
 																				{
 																					"name": "name",
 																					"string": {
-																						"computed_optional_required": "computed_optional",
-																						"description": "",
-																						"sensitive": false
+																						"computed_optional_required": "computed_optional"
 																					}
 																				}
 																			],
@@ -499,7 +456,6 @@
 																		"string": {
 																			"computed_optional_required": "computed_optional",
 																			"description": "The volume state.",
-																			"sensitive": false,
 																			"validators": [
 																				{
 																					"custom": {
@@ -529,7 +485,6 @@
 																		"string": {
 																			"computed_optional_required": "computed_optional",
 																			"description": "The volume type.",
-																			"sensitive": false,
 																			"validators": [
 																				{
 																					"custom": {
@@ -548,71 +503,56 @@
 																		"name": "zone",
 																		"string": {
 																			"computed_optional_required": "computed_optional",
-																			"description": "The zone in which is the volume.",
-																			"sensitive": false
+																			"description": "The zone in which is the volume."
 																		}
 																	}
-																],
-																"description": ""
+																]
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "from_server",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "modification_date",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "(RFC 3339 format)",
-													"sensitive": false
+													"description": "(RFC 3339 format)"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "organization",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "project",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "public",
 												"bool": {
-													"computed_optional_required": "computed_optional",
-													"description": ""
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -623,17 +563,13 @@
 														{
 															"name": "id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "name",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
@@ -647,8 +583,6 @@
 															"name": "volume_type",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false,
 																"validators": [
 																	{
 																		"custom": {
@@ -663,16 +597,13 @@
 																]
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											},
 											{
 												"name": "state",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -693,16 +624,13 @@
 													"computed_optional_required": "computed_optional",
 													"element_type": {
 														"string": {}
-													},
-													"description": ""
+													}
 												}
 											},
 											{
 												"name": "zone",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -718,24 +646,21 @@
 												"name": "address",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The server IPv6 IP-Address. (IPv6 address)",
-													"sensitive": false
+													"description": "The server IPv6 IP-Address. (IPv6 address)"
 												}
 											},
 											{
 												"name": "gateway",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The IPv6 IP-addresses gateway. (IPv6 address)",
-													"sensitive": false
+													"description": "The IPv6 IP-addresses gateway. (IPv6 address)"
 												}
 											},
 											{
 												"name": "netmask",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The IPv6 IP-addresses CIDR netmask.",
-													"sensitive": false
+													"description": "The IPv6 IP-addresses CIDR netmask."
 												}
 											}
 										],
@@ -750,41 +675,31 @@
 											{
 												"name": "cluster_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "hypervisor_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "node_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "platform_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "zone_id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -800,9 +715,7 @@
 												{
 													"name": "reason",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												}
 											]
@@ -814,24 +727,21 @@
 									"name": "modification_date",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server modification date. (RFC 3339 format)",
-										"sensitive": false
+										"description": "The server modification date. (RFC 3339 format)"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server name.",
-										"sensitive": false
+										"description": "The server name."
 									}
 								},
 								{
 									"name": "organization",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server organization ID.",
-										"sensitive": false
+										"description": "The server organization ID."
 									}
 								},
 								{
@@ -843,24 +753,21 @@
 												"name": "id",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The placement group unique ID.",
-													"sensitive": false
+													"description": "The placement group unique ID."
 												}
 											},
 											{
 												"name": "name",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The placement group name.",
-													"sensitive": false
+													"description": "The placement group name."
 												}
 											},
 											{
 												"name": "organization",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The placement group organization ID.",
-													"sensitive": false
+													"description": "The placement group organization ID."
 												}
 											},
 											{
@@ -868,7 +775,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "Select the failling mode when the placement cannot be respected, either optional or enforced.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -895,7 +801,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "Select the behavior of the placement group, either low_latency (group) or max_availability (spread).",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -914,8 +819,7 @@
 												"name": "project",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The placement group project ID.",
-													"sensitive": false
+													"description": "The placement group project ID."
 												}
 											},
 											{
@@ -932,8 +836,7 @@
 												"name": "zone",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The zone in which is the placement group.",
-													"sensitive": false
+													"description": "The zone in which is the placement group."
 												}
 											}
 										],
@@ -944,8 +847,7 @@
 									"name": "private_ip",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server private IP address.",
-										"sensitive": false
+										"description": "The server private IP address."
 									}
 								},
 								{
@@ -958,32 +860,28 @@
 													"name": "id",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The private NIC unique ID.",
-														"sensitive": false
+														"description": "The private NIC unique ID."
 													}
 												},
 												{
 													"name": "mac_address",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The private NIC MAC address.",
-														"sensitive": false
+														"description": "The private NIC MAC address."
 													}
 												},
 												{
 													"name": "private_network_id",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The private network where the private NIC is attached.",
-														"sensitive": false
+														"description": "The private network where the private NIC is attached."
 													}
 												},
 												{
 													"name": "server_id",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The server the private NIC is attached to.",
-														"sensitive": false
+														"description": "The server the private NIC is attached to."
 													}
 												},
 												{
@@ -991,7 +889,6 @@
 													"string": {
 														"computed_optional_required": "computed_optional",
 														"description": "The private NIC state.",
-														"sensitive": false,
 														"validators": [
 															{
 																"custom": {
@@ -1025,8 +922,7 @@
 									"name": "project",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server project ID.",
-										"sensitive": false
+										"description": "The server project ID."
 									}
 								},
 								{
@@ -1045,8 +941,7 @@
 												"name": "address",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The server public IPv4 IP-Address. (IPv4 address)",
-													"sensitive": false
+													"description": "The server public IPv4 IP-Address. (IPv4 address)"
 												}
 											},
 											{
@@ -1060,8 +955,7 @@
 												"name": "id",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The unique ID of the IP address.",
-													"sensitive": false
+													"description": "The unique ID of the IP address."
 												}
 											}
 										],
@@ -1076,17 +970,13 @@
 											{
 												"name": "id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
 										],
@@ -1098,7 +988,6 @@
 									"string": {
 										"computed_optional_required": "computed_optional",
 										"description": "The server state.",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -1117,8 +1006,7 @@
 									"name": "state_detail",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The server state_detail.",
-										"sensitive": false
+										"description": "The server state_detail."
 									}
 								},
 								{
@@ -1144,64 +1032,51 @@
 														{
 															"name": "boot",
 															"bool": {
-																"computed_optional_required": "computed_optional",
-																"description": ""
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "creation_date",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "(RFC 3339 format)",
-																"sensitive": false
+																"description": "(RFC 3339 format)"
 															}
 														},
 														{
 															"name": "export_uri",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "id",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "modification_date",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "(RFC 3339 format)",
-																"sensitive": false
+																"description": "(RFC 3339 format)"
 															}
 														},
 														{
 															"name": "name",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "organization",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
 															"name": "project",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														},
 														{
@@ -1212,21 +1087,16 @@
 																	{
 																		"name": "id",
 																		"string": {
-																			"computed_optional_required": "computed_optional",
-																			"description": "",
-																			"sensitive": false
+																			"computed_optional_required": "computed_optional"
 																		}
 																	},
 																	{
 																		"name": "name",
 																		"string": {
-																			"computed_optional_required": "computed_optional",
-																			"description": "",
-																			"sensitive": false
+																			"computed_optional_required": "computed_optional"
 																		}
 																	}
-																],
-																"description": ""
+																]
 															}
 														},
 														{
@@ -1240,8 +1110,6 @@
 															"name": "state",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false,
 																"validators": [
 																	{
 																		"custom": {
@@ -1260,8 +1128,6 @@
 															"name": "volume_type",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false,
 																"validators": [
 																	{
 																		"custom": {
@@ -1279,13 +1145,10 @@
 														{
 															"name": "zone",
 															"string": {
-																"computed_optional_required": "computed_optional",
-																"description": "",
-																"sensitive": false
+																"computed_optional_required": "computed_optional"
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											}
 										],
@@ -1296,12 +1159,10 @@
 									"name": "zone",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "The zone in which is the server.",
-										"sensitive": false
+										"description": "The zone in which is the server."
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					}
 				]
@@ -1316,7 +1177,6 @@
 						"string": {
 							"computed_optional_required": "required",
 							"description": "The zone you want to target",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -1349,32 +1209,28 @@
 						"name": "organization",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "List only servers of this organization ID.",
-							"sensitive": false
+							"description": "List only servers of this organization ID."
 						}
 					},
 					{
 						"name": "project",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "List only servers of this project ID.",
-							"sensitive": false
+							"description": "List only servers of this project ID."
 						}
 					},
 					{
 						"name": "name",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "Filter servers by name (for eg. \"server1\" will return \"server100\" and \"server1\" but not \"foo\").",
-							"sensitive": false
+							"description": "Filter servers by name (for eg. \"server1\" will return \"server100\" and \"server1\" but not \"foo\")."
 						}
 					},
 					{
 						"name": "private_ip",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "List servers by private_ip. (IP address)",
-							"sensitive": false
+							"description": "List servers by private_ip. (IP address)"
 						}
 					},
 					{
@@ -1388,8 +1244,7 @@
 						"name": "commercial_type",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "List servers of this commercial type.",
-							"sensitive": false
+							"description": "List servers of this commercial type."
 						}
 					},
 					{
@@ -1397,7 +1252,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "List servers in this state.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -1416,16 +1270,14 @@
 						"name": "tags",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "List servers with these exact tags (to filter with several tags, use commas to separate them).",
-							"sensitive": false
+							"description": "List servers with these exact tags (to filter with several tags, use commas to separate them)."
 						}
 					},
 					{
 						"name": "private_network",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "List servers in this Private Network.",
-							"sensitive": false
+							"description": "List servers in this Private Network."
 						}
 					},
 					{
@@ -1433,7 +1285,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "Define the order of the returned servers.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -1469,7 +1320,6 @@
 										"string": {
 											"computed_optional_required": "computed_optional",
 											"description": "The server arch.",
-											"sensitive": false,
 											"validators": [
 												{
 													"custom": {
@@ -1489,7 +1339,6 @@
 										"string": {
 											"computed_optional_required": "computed_optional",
 											"description": "The server boot type.",
-											"sensitive": false,
 											"validators": [
 												{
 													"custom": {
@@ -1514,7 +1363,6 @@
 													"string": {
 														"computed_optional_required": "computed_optional",
 														"description": "The bootscript arch.",
-														"sensitive": false,
 														"validators": [
 															{
 																"custom": {
@@ -1533,8 +1381,7 @@
 													"name": "bootcmdargs",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The bootscript arguments.",
-														"sensitive": false
+														"description": "The bootscript arguments."
 													}
 												},
 												{
@@ -1548,48 +1395,42 @@
 													"name": "dtb",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers.",
-														"sensitive": false
+														"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers."
 													}
 												},
 												{
 													"name": "id",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The bootscript ID.",
-														"sensitive": false
+														"description": "The bootscript ID."
 													}
 												},
 												{
 													"name": "initrd",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The initrd (initial ramdisk) configuration.",
-														"sensitive": false
+														"description": "The initrd (initial ramdisk) configuration."
 													}
 												},
 												{
 													"name": "kernel",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The server kernel version.",
-														"sensitive": false
+														"description": "The server kernel version."
 													}
 												},
 												{
 													"name": "organization",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The bootscript organization ID.",
-														"sensitive": false
+														"description": "The bootscript organization ID."
 													}
 												},
 												{
 													"name": "project",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The bootscript project ID.",
-														"sensitive": false
+														"description": "The bootscript project ID."
 													}
 												},
 												{
@@ -1603,16 +1444,14 @@
 													"name": "title",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The bootscript title.",
-														"sensitive": false
+														"description": "The bootscript title."
 													}
 												},
 												{
 													"name": "zone",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The zone in which is the bootscript.",
-														"sensitive": false
+														"description": "The zone in which is the bootscript."
 													}
 												}
 											],
@@ -1623,16 +1462,14 @@
 										"name": "commercial_type",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server commercial type (eg. GP1-M).",
-											"sensitive": false
+											"description": "The server commercial type (eg. GP1-M)."
 										}
 									},
 									{
 										"name": "creation_date",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server creation date. (RFC 3339 format)",
-											"sensitive": false
+											"description": "The server creation date. (RFC 3339 format)"
 										}
 									},
 									{
@@ -1653,16 +1490,14 @@
 										"name": "hostname",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server host name.",
-											"sensitive": false
+											"description": "The server host name."
 										}
 									},
 									{
 										"name": "id",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server unique ID.",
-											"sensitive": false
+											"description": "The server unique ID."
 										}
 									},
 									{
@@ -1674,8 +1509,6 @@
 													"name": "arch",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false,
 														"validators": [
 															{
 																"custom": {
@@ -1694,8 +1527,7 @@
 													"name": "creation_date",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "(RFC 3339 format)",
-														"sensitive": false
+														"description": "(RFC 3339 format)"
 													}
 												},
 												{
@@ -1708,7 +1540,6 @@
 																"string": {
 																	"computed_optional_required": "computed_optional",
 																	"description": "The bootscript arch.",
-																	"sensitive": false,
 																	"validators": [
 																		{
 																			"custom": {
@@ -1727,8 +1558,7 @@
 																"name": "bootcmdargs",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The bootscript arguments.",
-																	"sensitive": false
+																	"description": "The bootscript arguments."
 																}
 															},
 															{
@@ -1742,48 +1572,42 @@
 																"name": "dtb",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers.",
-																	"sensitive": false
+																	"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers."
 																}
 															},
 															{
 																"name": "id",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The bootscript ID.",
-																	"sensitive": false
+																	"description": "The bootscript ID."
 																}
 															},
 															{
 																"name": "initrd",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The initrd (initial ramdisk) configuration.",
-																	"sensitive": false
+																	"description": "The initrd (initial ramdisk) configuration."
 																}
 															},
 															{
 																"name": "kernel",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The server kernel version.",
-																	"sensitive": false
+																	"description": "The server kernel version."
 																}
 															},
 															{
 																"name": "organization",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The bootscript organization ID.",
-																	"sensitive": false
+																	"description": "The bootscript organization ID."
 																}
 															},
 															{
 																"name": "project",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The bootscript project ID.",
-																	"sensitive": false
+																	"description": "The bootscript project ID."
 																}
 															},
 															{
@@ -1797,20 +1621,17 @@
 																"name": "title",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The bootscript title.",
-																	"sensitive": false
+																	"description": "The bootscript title."
 																}
 															},
 															{
 																"name": "zone",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "The zone in which is the bootscript.",
-																	"sensitive": false
+																	"description": "The zone in which is the bootscript."
 																}
 															}
-														],
-														"description": ""
+														]
 													}
 												},
 												{
@@ -1827,56 +1648,49 @@
 																			"name": "creation_date",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The volume creation date. (RFC 3339 format)",
-																				"sensitive": false
+																				"description": "The volume creation date. (RFC 3339 format)"
 																			}
 																		},
 																		{
 																			"name": "export_uri",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "Show the volume NBD export URI.",
-																				"sensitive": false
+																				"description": "Show the volume NBD export URI."
 																			}
 																		},
 																		{
 																			"name": "id",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The volume unique ID.",
-																				"sensitive": false
+																				"description": "The volume unique ID."
 																			}
 																		},
 																		{
 																			"name": "modification_date",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The volume modification date. (RFC 3339 format)",
-																				"sensitive": false
+																				"description": "The volume modification date. (RFC 3339 format)"
 																			}
 																		},
 																		{
 																			"name": "name",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The volume name.",
-																				"sensitive": false
+																				"description": "The volume name."
 																			}
 																		},
 																		{
 																			"name": "organization",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The volume organization ID.",
-																				"sensitive": false
+																				"description": "The volume organization ID."
 																			}
 																		},
 																		{
 																			"name": "project",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The volume project ID.",
-																				"sensitive": false
+																				"description": "The volume project ID."
 																			}
 																		},
 																		{
@@ -1887,17 +1701,13 @@
 																					{
 																						"name": "id",
 																						"string": {
-																							"computed_optional_required": "computed_optional",
-																							"description": "",
-																							"sensitive": false
+																							"computed_optional_required": "computed_optional"
 																						}
 																					},
 																					{
 																						"name": "name",
 																						"string": {
-																							"computed_optional_required": "computed_optional",
-																							"description": "",
-																							"sensitive": false
+																							"computed_optional_required": "computed_optional"
 																						}
 																					}
 																				],
@@ -1916,7 +1726,6 @@
 																			"string": {
 																				"computed_optional_required": "computed_optional",
 																				"description": "The volume state.",
-																				"sensitive": false,
 																				"validators": [
 																					{
 																						"custom": {
@@ -1946,7 +1755,6 @@
 																			"string": {
 																				"computed_optional_required": "computed_optional",
 																				"description": "The volume type.",
-																				"sensitive": false,
 																				"validators": [
 																					{
 																						"custom": {
@@ -1965,71 +1773,56 @@
 																			"name": "zone",
 																			"string": {
 																				"computed_optional_required": "computed_optional",
-																				"description": "The zone in which is the volume.",
-																				"sensitive": false
+																				"description": "The zone in which is the volume."
 																			}
 																		}
-																	],
-																	"description": ""
+																	]
 																}
 															}
-														],
-														"description": ""
+														]
 													}
 												},
 												{
 													"name": "from_server",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "modification_date",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "(RFC 3339 format)",
-														"sensitive": false
+														"description": "(RFC 3339 format)"
 													}
 												},
 												{
 													"name": "name",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "organization",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "project",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "public",
 													"bool": {
-														"computed_optional_required": "computed_optional",
-														"description": ""
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
@@ -2040,17 +1833,13 @@
 															{
 																"name": "id",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
 																"name": "name",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
@@ -2064,8 +1853,6 @@
 																"name": "volume_type",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false,
 																	"validators": [
 																		{
 																			"custom": {
@@ -2080,16 +1867,13 @@
 																	]
 																}
 															}
-														],
-														"description": ""
+														]
 													}
 												},
 												{
 													"name": "state",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false,
 														"validators": [
 															{
 																"custom": {
@@ -2110,16 +1894,13 @@
 														"computed_optional_required": "computed_optional",
 														"element_type": {
 															"string": {}
-														},
-														"description": ""
+														}
 													}
 												},
 												{
 													"name": "zone",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												}
 											],
@@ -2135,24 +1916,21 @@
 													"name": "address",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The server IPv6 IP-Address. (IPv6 address)",
-														"sensitive": false
+														"description": "The server IPv6 IP-Address. (IPv6 address)"
 													}
 												},
 												{
 													"name": "gateway",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The IPv6 IP-addresses gateway. (IPv6 address)",
-														"sensitive": false
+														"description": "The IPv6 IP-addresses gateway. (IPv6 address)"
 													}
 												},
 												{
 													"name": "netmask",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The IPv6 IP-addresses CIDR netmask.",
-														"sensitive": false
+														"description": "The IPv6 IP-addresses CIDR netmask."
 													}
 												}
 											],
@@ -2167,41 +1945,31 @@
 												{
 													"name": "cluster_id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "hypervisor_id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "node_id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "platform_id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "zone_id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												}
 											],
@@ -2217,9 +1985,7 @@
 													{
 														"name": "reason",
 														"string": {
-															"computed_optional_required": "computed_optional",
-															"description": "",
-															"sensitive": false
+															"computed_optional_required": "computed_optional"
 														}
 													}
 												]
@@ -2231,24 +1997,21 @@
 										"name": "modification_date",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server modification date. (RFC 3339 format)",
-											"sensitive": false
+											"description": "The server modification date. (RFC 3339 format)"
 										}
 									},
 									{
 										"name": "name",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server name.",
-											"sensitive": false
+											"description": "The server name."
 										}
 									},
 									{
 										"name": "organization",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server organization ID.",
-											"sensitive": false
+											"description": "The server organization ID."
 										}
 									},
 									{
@@ -2260,24 +2023,21 @@
 													"name": "id",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The placement group unique ID.",
-														"sensitive": false
+														"description": "The placement group unique ID."
 													}
 												},
 												{
 													"name": "name",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The placement group name.",
-														"sensitive": false
+														"description": "The placement group name."
 													}
 												},
 												{
 													"name": "organization",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The placement group organization ID.",
-														"sensitive": false
+														"description": "The placement group organization ID."
 													}
 												},
 												{
@@ -2285,7 +2045,6 @@
 													"string": {
 														"computed_optional_required": "computed_optional",
 														"description": "Select the failling mode when the placement cannot be respected, either optional or enforced.",
-														"sensitive": false,
 														"validators": [
 															{
 																"custom": {
@@ -2312,7 +2071,6 @@
 													"string": {
 														"computed_optional_required": "computed_optional",
 														"description": "Select the behavior of the placement group, either low_latency (group) or max_availability (spread).",
-														"sensitive": false,
 														"validators": [
 															{
 																"custom": {
@@ -2331,8 +2089,7 @@
 													"name": "project",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The placement group project ID.",
-														"sensitive": false
+														"description": "The placement group project ID."
 													}
 												},
 												{
@@ -2349,8 +2106,7 @@
 													"name": "zone",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The zone in which is the placement group.",
-														"sensitive": false
+														"description": "The zone in which is the placement group."
 													}
 												}
 											],
@@ -2361,8 +2117,7 @@
 										"name": "private_ip",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server private IP address.",
-											"sensitive": false
+											"description": "The server private IP address."
 										}
 									},
 									{
@@ -2375,32 +2130,28 @@
 														"name": "id",
 														"string": {
 															"computed_optional_required": "computed_optional",
-															"description": "The private NIC unique ID.",
-															"sensitive": false
+															"description": "The private NIC unique ID."
 														}
 													},
 													{
 														"name": "mac_address",
 														"string": {
 															"computed_optional_required": "computed_optional",
-															"description": "The private NIC MAC address.",
-															"sensitive": false
+															"description": "The private NIC MAC address."
 														}
 													},
 													{
 														"name": "private_network_id",
 														"string": {
 															"computed_optional_required": "computed_optional",
-															"description": "The private network where the private NIC is attached.",
-															"sensitive": false
+															"description": "The private network where the private NIC is attached."
 														}
 													},
 													{
 														"name": "server_id",
 														"string": {
 															"computed_optional_required": "computed_optional",
-															"description": "The server the private NIC is attached to.",
-															"sensitive": false
+															"description": "The server the private NIC is attached to."
 														}
 													},
 													{
@@ -2408,7 +2159,6 @@
 														"string": {
 															"computed_optional_required": "computed_optional",
 															"description": "The private NIC state.",
-															"sensitive": false,
 															"validators": [
 																{
 																	"custom": {
@@ -2442,8 +2192,7 @@
 										"name": "project",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server project ID.",
-											"sensitive": false
+											"description": "The server project ID."
 										}
 									},
 									{
@@ -2462,8 +2211,7 @@
 													"name": "address",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The server public IPv4 IP-Address. (IPv4 address)",
-														"sensitive": false
+														"description": "The server public IPv4 IP-Address. (IPv4 address)"
 													}
 												},
 												{
@@ -2477,8 +2225,7 @@
 													"name": "id",
 													"string": {
 														"computed_optional_required": "computed_optional",
-														"description": "The unique ID of the IP address.",
-														"sensitive": false
+														"description": "The unique ID of the IP address."
 													}
 												}
 											],
@@ -2493,17 +2240,13 @@
 												{
 													"name": "id",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												},
 												{
 													"name": "name",
 													"string": {
-														"computed_optional_required": "computed_optional",
-														"description": "",
-														"sensitive": false
+														"computed_optional_required": "computed_optional"
 													}
 												}
 											],
@@ -2515,7 +2258,6 @@
 										"string": {
 											"computed_optional_required": "computed_optional",
 											"description": "The server state.",
-											"sensitive": false,
 											"validators": [
 												{
 													"custom": {
@@ -2534,8 +2276,7 @@
 										"name": "state_detail",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The server state_detail.",
-											"sensitive": false
+											"description": "The server state_detail."
 										}
 									},
 									{
@@ -2561,64 +2302,51 @@
 															{
 																"name": "boot",
 																"bool": {
-																	"computed_optional_required": "computed_optional",
-																	"description": ""
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
 																"name": "creation_date",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "(RFC 3339 format)",
-																	"sensitive": false
+																	"description": "(RFC 3339 format)"
 																}
 															},
 															{
 																"name": "export_uri",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
 																"name": "id",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
 																"name": "modification_date",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "(RFC 3339 format)",
-																	"sensitive": false
+																	"description": "(RFC 3339 format)"
 																}
 															},
 															{
 																"name": "name",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
 																"name": "organization",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
 																"name": "project",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															},
 															{
@@ -2629,21 +2357,16 @@
 																		{
 																			"name": "id",
 																			"string": {
-																				"computed_optional_required": "computed_optional",
-																				"description": "",
-																				"sensitive": false
+																				"computed_optional_required": "computed_optional"
 																			}
 																		},
 																		{
 																			"name": "name",
 																			"string": {
-																				"computed_optional_required": "computed_optional",
-																				"description": "",
-																				"sensitive": false
+																				"computed_optional_required": "computed_optional"
 																			}
 																		}
-																	],
-																	"description": ""
+																	]
 																}
 															},
 															{
@@ -2657,8 +2380,6 @@
 																"name": "state",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false,
 																	"validators": [
 																		{
 																			"custom": {
@@ -2677,8 +2398,6 @@
 																"name": "volume_type",
 																"string": {
 																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false,
 																	"validators": [
 																		{
 																			"custom": {
@@ -2696,13 +2415,10 @@
 															{
 																"name": "zone",
 																"string": {
-																	"computed_optional_required": "computed_optional",
-																	"description": "",
-																	"sensitive": false
+																	"computed_optional_required": "computed_optional"
 																}
 															}
-														],
-														"description": ""
+														]
 													}
 												}
 											],
@@ -2713,8 +2429,7 @@
 										"name": "zone",
 										"string": {
 											"computed_optional_required": "computed_optional",
-											"description": "The zone in which is the server.",
-											"sensitive": false
+											"description": "The zone in which is the server."
 										}
 									}
 								]
@@ -2739,7 +2454,6 @@
 						"string": {
 							"computed_optional_required": "required",
 							"description": "Architecture of the image.",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -2758,8 +2472,7 @@
 						"name": "default_bootscript",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "Default bootscript of the image.",
-							"sensitive": false
+							"description": "Default bootscript of the image."
 						}
 					},
 					{
@@ -2776,32 +2489,28 @@
 												"name": "id",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "UUID of the volume.",
-													"sensitive": false
+													"description": "UUID of the volume."
 												}
 											},
 											{
 												"name": "name",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "Name of the volume.",
-													"sensitive": false
+													"description": "Name of the volume."
 												}
 											},
 											{
 												"name": "organization",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "Organization ID of the volume.",
-													"sensitive": false
+													"description": "Organization ID of the volume."
 												}
 											},
 											{
 												"name": "project",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "Project ID of the volume.",
-													"sensitive": false
+													"description": "Project ID of the volume."
 												}
 											},
 											{
@@ -2816,7 +2525,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "Type of the volume.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -2831,8 +2539,7 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								}
 							],
@@ -2843,24 +2550,21 @@
 						"name": "name",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "Name of the image.",
-							"sensitive": false
+							"description": "Name of the image."
 						}
 					},
 					{
 						"name": "organization",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "Organization ID of the image.",
-							"sensitive": false
+							"description": "Organization ID of the image."
 						}
 					},
 					{
 						"name": "project",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "Project ID of the image.",
-							"sensitive": false
+							"description": "Project ID of the image."
 						}
 					},
 					{
@@ -2874,8 +2578,7 @@
 						"name": "root_volume",
 						"string": {
 							"computed_optional_required": "required",
-							"description": "UUID of the snapshot.",
-							"sensitive": false
+							"description": "UUID of the snapshot."
 						}
 					},
 					{
@@ -2897,8 +2600,6 @@
 									"name": "arch",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -2917,8 +2618,7 @@
 									"name": "creation_date",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "(RFC 3339 format)",
-										"sensitive": false
+										"description": "(RFC 3339 format)"
 									}
 								},
 								{
@@ -2931,7 +2631,6 @@
 												"string": {
 													"computed_optional_required": "computed_optional",
 													"description": "The bootscript arch.",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -2950,8 +2649,7 @@
 												"name": "bootcmdargs",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript arguments.",
-													"sensitive": false
+													"description": "The bootscript arguments."
 												}
 											},
 											{
@@ -2965,48 +2663,42 @@
 												"name": "dtb",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers.",
-													"sensitive": false
+													"description": "Provide information regarding a Device Tree Binary (dtb) for use with C1 servers."
 												}
 											},
 											{
 												"name": "id",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript ID.",
-													"sensitive": false
+													"description": "The bootscript ID."
 												}
 											},
 											{
 												"name": "initrd",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The initrd (initial ramdisk) configuration.",
-													"sensitive": false
+													"description": "The initrd (initial ramdisk) configuration."
 												}
 											},
 											{
 												"name": "kernel",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The server kernel version.",
-													"sensitive": false
+													"description": "The server kernel version."
 												}
 											},
 											{
 												"name": "organization",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript organization ID.",
-													"sensitive": false
+													"description": "The bootscript organization ID."
 												}
 											},
 											{
 												"name": "project",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript project ID.",
-													"sensitive": false
+													"description": "The bootscript project ID."
 												}
 											},
 											{
@@ -3020,20 +2712,17 @@
 												"name": "title",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The bootscript title.",
-													"sensitive": false
+													"description": "The bootscript title."
 												}
 											},
 											{
 												"name": "zone",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "The zone in which is the bootscript.",
-													"sensitive": false
+													"description": "The zone in which is the bootscript."
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -3050,56 +2739,49 @@
 															"name": "creation_date",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The volume creation date. (RFC 3339 format)",
-																"sensitive": false
+																"description": "The volume creation date. (RFC 3339 format)"
 															}
 														},
 														{
 															"name": "export_uri",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "Show the volume NBD export URI.",
-																"sensitive": false
+																"description": "Show the volume NBD export URI."
 															}
 														},
 														{
 															"name": "id",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The volume unique ID.",
-																"sensitive": false
+																"description": "The volume unique ID."
 															}
 														},
 														{
 															"name": "modification_date",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The volume modification date. (RFC 3339 format)",
-																"sensitive": false
+																"description": "The volume modification date. (RFC 3339 format)"
 															}
 														},
 														{
 															"name": "name",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The volume name.",
-																"sensitive": false
+																"description": "The volume name."
 															}
 														},
 														{
 															"name": "organization",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The volume organization ID.",
-																"sensitive": false
+																"description": "The volume organization ID."
 															}
 														},
 														{
 															"name": "project",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The volume project ID.",
-																"sensitive": false
+																"description": "The volume project ID."
 															}
 														},
 														{
@@ -3110,17 +2792,13 @@
 																	{
 																		"name": "id",
 																		"string": {
-																			"computed_optional_required": "computed_optional",
-																			"description": "",
-																			"sensitive": false
+																			"computed_optional_required": "computed_optional"
 																		}
 																	},
 																	{
 																		"name": "name",
 																		"string": {
-																			"computed_optional_required": "computed_optional",
-																			"description": "",
-																			"sensitive": false
+																			"computed_optional_required": "computed_optional"
 																		}
 																	}
 																],
@@ -3139,7 +2817,6 @@
 															"string": {
 																"computed_optional_required": "computed_optional",
 																"description": "The volume state.",
-																"sensitive": false,
 																"validators": [
 																	{
 																		"custom": {
@@ -3169,7 +2846,6 @@
 															"string": {
 																"computed_optional_required": "computed_optional",
 																"description": "The volume type.",
-																"sensitive": false,
 																"validators": [
 																	{
 																		"custom": {
@@ -3188,71 +2864,56 @@
 															"name": "zone",
 															"string": {
 																"computed_optional_required": "computed_optional",
-																"description": "The zone in which is the volume.",
-																"sensitive": false
+																"description": "The zone in which is the volume."
 															}
 														}
-													],
-													"description": ""
+													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
 									"name": "from_server",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "modification_date",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "(RFC 3339 format)",
-										"sensitive": false
+										"description": "(RFC 3339 format)"
 									}
 								},
 								{
 									"name": "name",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "organization",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "project",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "public",
 									"bool": {
-										"computed_optional_required": "computed_optional",
-										"description": ""
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3263,17 +2924,13 @@
 											{
 												"name": "id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
@@ -3287,8 +2944,6 @@
 												"name": "volume_type",
 												"string": {
 													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false,
 													"validators": [
 														{
 															"custom": {
@@ -3303,16 +2958,13 @@
 													]
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
 									"name": "state",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false,
 										"validators": [
 											{
 												"custom": {
@@ -3333,20 +2985,16 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "zone",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
@@ -3354,7 +3002,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The zone you want to target",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {
@@ -3373,8 +3020,7 @@
 						"name": "image_id",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "UUID of the image you want to get.",
-							"sensitive": false
+							"description": "UUID of the image you want to get."
 						}
 					}
 				]
@@ -3388,24 +3034,21 @@
 						"name": "organization",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The organization ID the IP is reserved in.",
-							"sensitive": false
+							"description": "The organization ID the IP is reserved in."
 						}
 					},
 					{
 						"name": "project",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "The project ID the IP is reserved in.",
-							"sensitive": false
+							"description": "The project ID the IP is reserved in."
 						}
 					},
 					{
 						"name": "server",
 						"string": {
 							"computed_optional_required": "computed_optional",
-							"description": "UUID of the server you want to attach the IP to.",
-							"sensitive": false
+							"description": "UUID of the server you want to attach the IP to."
 						}
 					},
 					{
@@ -3427,40 +3070,31 @@
 									"name": "address",
 									"string": {
 										"computed_optional_required": "computed_optional",
-										"description": "(IPv4 address)",
-										"sensitive": false
+										"description": "(IPv4 address)"
 									}
 								},
 								{
 									"name": "id",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "organization",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "project",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
 									"name": "reverse",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								},
 								{
@@ -3471,21 +3105,16 @@
 											{
 												"name": "id",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											},
 											{
 												"name": "name",
 												"string": {
-													"computed_optional_required": "computed_optional",
-													"description": "",
-													"sensitive": false
+													"computed_optional_required": "computed_optional"
 												}
 											}
-										],
-										"description": ""
+										]
 									}
 								},
 								{
@@ -3494,20 +3123,16 @@
 										"computed_optional_required": "computed_optional",
 										"element_type": {
 											"string": {}
-										},
-										"description": ""
+										}
 									}
 								},
 								{
 									"name": "zone",
 									"string": {
-										"computed_optional_required": "computed_optional",
-										"description": "",
-										"sensitive": false
+										"computed_optional_required": "computed_optional"
 									}
 								}
-							],
-							"description": ""
+							]
 						}
 					},
 					{
@@ -3515,7 +3140,6 @@
 						"string": {
 							"computed_optional_required": "computed_optional",
 							"description": "The zone you want to target",
-							"sensitive": false,
 							"validators": [
 								{
 									"custom": {

--- a/internal/mapper/datasource_mapper_test.go
+++ b/internal/mapper/datasource_mapper_test.go
@@ -341,7 +341,6 @@ func TestDataSourceMapper_basic_merges(t *testing.T) {
 													String: &datasource.StringAttribute{
 														ComputedOptionalRequired: schema.ComputedOptional,
 														Description:              pointer("hey this is a string!"),
-														Sensitive:                pointer(false),
 													},
 												},
 											},

--- a/internal/mapper/oas/build_test.go
+++ b/internal/mapper/oas/build_test.go
@@ -501,7 +501,6 @@ func TestBuildSchema_NullableMultiTypes(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.ComputedOptional,
 						Description:              pointer("hey there! I'm a nullable string type."),
-						Sensitive:                pointer(false),
 					},
 				},
 				{
@@ -509,7 +508,6 @@ func TestBuildSchema_NullableMultiTypes(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
 						Description:              pointer("hey there! I'm a nullable string type, required."),
-						Sensitive:                pointer(false),
 					},
 				},
 			},
@@ -549,7 +547,6 @@ func TestBuildSchema_NullableMultiTypes(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.ComputedOptional,
 						Description:              pointer("hey there! I'm a string type."),
-						Sensitive:                pointer(false),
 					},
 				},
 				{
@@ -557,7 +554,6 @@ func TestBuildSchema_NullableMultiTypes(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
 						Description:              pointer("hey there! I'm a string type, required."),
-						Sensitive:                pointer(false),
 					},
 				},
 			},
@@ -597,7 +593,6 @@ func TestBuildSchema_NullableMultiTypes(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.ComputedOptional,
 						Description:              pointer("hey there! I'm a string type."),
-						Sensitive:                pointer(false),
 					},
 				},
 				{
@@ -605,7 +600,6 @@ func TestBuildSchema_NullableMultiTypes(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
 						Description:              pointer("hey there! I'm a string type, required."),
-						Sensitive:                pointer(false),
 					},
 				},
 			},

--- a/internal/mapper/oas/collection_test.go
+++ b/internal/mapper/oas/collection_test.go
@@ -110,14 +110,12 @@ func TestBuildCollectionResource(t *testing.T) {
 					Name: "nested_list_prop_required",
 					ListNested: &resource.ListNestedAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						NestedObject: resource.NestedAttributeObject{
 							Attributes: []resource.Attribute{
 								{
 									Name: "nested_int64_required",
 									Int64: &resource.Int64Attribute{
 										ComputedOptionalRequired: schema.Required,
-										Description:              pointer(""),
 									},
 								},
 							},
@@ -225,14 +223,12 @@ func TestBuildCollectionResource(t *testing.T) {
 					Name: "nested_set_prop_required",
 					SetNested: &resource.SetNestedAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						NestedObject: resource.NestedAttributeObject{
 							Attributes: []resource.Attribute{
 								{
 									Name: "nested_int64_required",
 									Int64: &resource.Int64Attribute{
 										ComputedOptionalRequired: schema.Required,
-										Description:              pointer(""),
 									},
 								},
 							},
@@ -688,14 +684,12 @@ func TestBuildCollectionDataSource(t *testing.T) {
 					Name: "nested_list_prop_required",
 					ListNested: &datasource.ListNestedAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						NestedObject: datasource.NestedAttributeObject{
 							Attributes: []datasource.Attribute{
 								{
 									Name: "nested_int64_required",
 									Int64: &datasource.Int64Attribute{
 										ComputedOptionalRequired: schema.Required,
-										Description:              pointer(""),
 									},
 								},
 							},
@@ -803,14 +797,12 @@ func TestBuildCollectionDataSource(t *testing.T) {
 					Name: "nested_set_prop_required",
 					SetNested: &datasource.SetNestedAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						NestedObject: datasource.NestedAttributeObject{
 							Attributes: []datasource.Attribute{
 								{
 									Name: "nested_int64_required",
 									Int64: &datasource.Int64Attribute{
 										ComputedOptionalRequired: schema.Required,
-										Description:              pointer(""),
 									},
 								},
 							},

--- a/internal/mapper/oas/integer_test.go
+++ b/internal/mapper/oas/integer_test.go
@@ -119,7 +119,6 @@ func TestBuildIntegerResource(t *testing.T) {
 					Name: "int64_prop",
 					Int64: &resource.Int64Attribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						Validators: []schema.Int64Validator{
 							{
 								Custom: &schema.CustomValidator{
@@ -260,7 +259,6 @@ func TestBuildIntegerDataSource(t *testing.T) {
 					Name: "int64_prop",
 					Int64: &datasource.Int64Attribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						Validators: []schema.Int64Validator{
 							{
 								Custom: &schema.CustomValidator{

--- a/internal/mapper/oas/map_test.go
+++ b/internal/mapper/oas/map_test.go
@@ -133,14 +133,12 @@ func TestBuildMapResource(t *testing.T) {
 					Name: "nested_map_prop_required",
 					MapNested: &resource.MapNestedAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						NestedObject: resource.NestedAttributeObject{
 							Attributes: []resource.Attribute{
 								{
 									Name: "nested_int64_required",
 									Int64: &resource.Int64Attribute{
 										ComputedOptionalRequired: schema.Required,
-										Description:              pointer(""),
 									},
 								},
 							},
@@ -344,14 +342,12 @@ func TestBuildMapDataSource(t *testing.T) {
 					Name: "nested_map_prop_required",
 					MapNested: &datasource.MapNestedAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						NestedObject: datasource.NestedAttributeObject{
 							Attributes: []datasource.Attribute{
 								{
 									Name: "nested_int64_required",
 									Int64: &datasource.Int64Attribute{
 										ComputedOptionalRequired: schema.Required,
-										Description:              pointer(""),
 									},
 								},
 							},

--- a/internal/mapper/oas/number_test.go
+++ b/internal/mapper/oas/number_test.go
@@ -98,7 +98,6 @@ func TestBuildNumberResource(t *testing.T) {
 					Name: "float64_prop",
 					Float64: &resource.Float64Attribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						Validators: []schema.Float64Validator{
 							{
 								Custom: &schema.CustomValidator{
@@ -388,7 +387,6 @@ func TestBuildNumberDataSource(t *testing.T) {
 					Name: "float64_prop",
 					Float64: &datasource.Float64Attribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
 						Validators: []schema.Float64Validator{
 							{
 								Custom: &schema.CustomValidator{

--- a/internal/mapper/oas/oas_schema.go
+++ b/internal/mapper/oas/oas_schema.go
@@ -52,12 +52,20 @@ func (s *OASSchema) GetDescription() *string {
 		return &s.SchemaOpts.OverrideDescription
 	}
 
+	if s.Schema.Description == "" {
+		return nil
+	}
+
 	// TODO: potentially use original description for nullable types?
 	return &s.Schema.Description
 }
 
 func (s *OASSchema) IsSensitive() *bool {
 	isSensitive := s.Format == util.OAS_format_password
+
+	if !isSensitive {
+		return nil
+	}
 
 	return &isSensitive
 }

--- a/internal/mapper/oas/string_test.go
+++ b/internal/mapper/oas/string_test.go
@@ -45,7 +45,6 @@ func TestBuildStringResource(t *testing.T) {
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
 						Description:              pointer("hey there! I'm a string type, not sensitive, required."),
-						Sensitive:                pointer(false),
 					},
 				},
 				{
@@ -122,8 +121,6 @@ func TestBuildStringResource(t *testing.T) {
 					Name: "string_prop",
 					String: &resource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
-						Sensitive:                pointer(false),
 						Validators: []schema.StringValidator{
 							{
 								Custom: &schema.CustomValidator{
@@ -190,7 +187,6 @@ func TestBuildStringDataSource(t *testing.T) {
 					String: &datasource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
 						Description:              pointer("hey there! I'm a string type, not sensitive, required."),
-						Sensitive:                pointer(false),
 					},
 				},
 				{
@@ -267,8 +263,6 @@ func TestBuildStringDataSource(t *testing.T) {
 					Name: "string_prop",
 					String: &datasource.StringAttribute{
 						ComputedOptionalRequired: schema.Required,
-						Description:              pointer(""),
-						Sensitive:                pointer(false),
 						Validators: []schema.StringValidator{
 							{
 								Custom: &schema.CustomValidator{

--- a/internal/mapper/resource_mapper_test.go
+++ b/internal/mapper/resource_mapper_test.go
@@ -351,7 +351,6 @@ func TestResourceMapper_basic_merges(t *testing.T) {
 													String: &resource.StringAttribute{
 														ComputedOptionalRequired: schema.ComputedOptional,
 														Description:              pointer("hey this is a string!"),
-														Sensitive:                pointer(false),
 													},
 												},
 												{


### PR DESCRIPTION
Closes #34
Closes #35

Slight cleanup of generated specification to reduce size where the omitted specification is the same as the desired behavior.