### PR TITLE
Add module version for remote github install

### DIFF
--- a/cmd/tfplugingen-openapi/main.go
+++ b/cmd/tfplugingen-openapi/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"runtime/debug"
@@ -18,18 +19,18 @@ import (
 // https://goreleaser.com/cookbooks/using-main.version/
 func main() {
 	name := "tfplugingen-openapi"
-	version := name + " commit: " + func() string {
+	version := name + func() string {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, setting := range info.Settings {
 				if setting.Key == "vcs.revision" {
-					return setting.Value
+					return fmt.Sprintf(" commit: %s", setting.Value)
 				}
 			}
 
-			return info.Main.Version
+			return fmt.Sprintf(" module: %s", info.Main.Version)
 		}
 
-		return "local"
+		return " local"
 	}()
 
 	os.Exit(runCLI(


### PR DESCRIPTION
Looks like the `vcs.revision` tag is only applied when installed from source.

### Current behavior

```bash
# Git clone the repository
# When installing, notices the `.git` folder and stamps the binary with vcs.* tags
$ go install ./cmd/tfplugingen-openapi
$ tfplugingen-openapi --version

tfplugingen-openapi commit: 406d3056a335fcef04927bebeac15350e73a9f66

# Install from remote
$ go install github.com/hashicorp/terraform-plugin-codegen-openapi/cmd/tfplugingen-openapi@latest
$ tfplugingen-openapi --version

tfplugingen-openapi commit: local
```

Since most of our docs reference `go install github.com/hashicorp/terraform-plugin-codegen-openapi/cmd/tfplugingen-openapi@latest`, it might be helpful to also grab the main go module version if `vcs` info is not available.

### After changes

```bash
# Git clone the repository/PR branch
$ go install ./cmd/tfplugingen-openapi
$ tfplugingen-openapi --version

tfplugingen-openapi commit: 6f7bc2c51ccd40fab1a8c56155247bf9688e3cd8

# Install from remote
$ go install github.com/hashicorp/terraform-plugin-codegen-openapi/cmd/tfplugingen-openapi@6f7bc2c51ccd40fab1a8c56155247bf9688e3cd8
$ tfplugingen-openapi --version

tfplugingen-openapi module: v0.0.0-20231004112425-6f7bc2c51ccd
```