### PR TITLE
Add data source support for response body arrays

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20231019-120611.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20231019-120611.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Added data source support for response body arrays
+time: 2023-10-19T12:06:11.101382-04:00
+custom:
+  Issue: "16"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -83,6 +83,79 @@ The response body schema found will be deep merged with the query/path `paramete
   - Names are strictly compared, so `id` and `user_id` would be two separate attributes in a schema.
 - Arrays and Objects will have their child attributes merged, so `example_object.string_field` and `example_object.bool_field` will be merged into the same `SingleNestedAttribute` schema.
 
+#### Collection Data Sources
+
+If the response body schema for a data source is of type `array`, the schema in `items` will be mapped to a collection attribute (`ListNested`, `SetNested`, `List`, `Set`) at the root of the mapped data source. The name of the attribute will be the same as the data source name from the generator config. All [mapping rules](#oas-types-to-provider-attributes) will be followed for nested attributes.
+
+##### Generator Config
+```yaml
+provider:
+  name: petstore
+
+data_sources:
+  pets:
+    read:
+      path: /pet/findByStatus
+      method: GET
+```
+
+##### OpenAPI Spec
+```jsonc
+{
+  // ... Rest of OAS
+  "/pet/findByStatus": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "successful operation",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+##### Provider Code Spec output
+```json
+{
+  "datasources": [
+    {
+      "name": "pets",
+      "schema": {
+        "attributes": [
+          {
+            "name": "pets",
+            "list_nested": {
+              "computed_optional_required": "computed",
+              "nested_object": {
+                "attributes": [
+                  // ... mapping of #/components/schemas/Pet
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "provider": {
+    "name": "petstore"
+  }
+}
+```
+
+
+
 ### OAS Types to Provider Attributes
 
 For a given OAS [`type`](https://spec.openapis.org/oas/v3.1.0#data-types) and `format` combination, the following rules will be applied for mapping to the provider code specification. Not all Provider attributes are represented natively with OAS, those types are noted below in [Unsupported Attributes](#unsupported-attributes).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,7 +85,7 @@ The response body schema found will be deep merged with the query/path `paramete
 
 #### Collection Data Sources
 
-If the response body schema for a data source is of type `array`, the schema in `items` will be mapped to a collection attribute (`ListNested`, `SetNested`, `List`, `Set`) at the root of the mapped data source. The name of the attribute will be the same as the data source name from the generator config. All [mapping rules](#oas-types-to-provider-attributes) will be followed for nested attributes.
+If the response body schema for a data source is of type `array`, the schema in `items` will be mapped to a set collection attribute (`SetNested` or `Set`) at the root of the mapped data source. The name of the attribute will be the same as the data source name from the generator config. All [mapping rules](#oas-types-to-provider-attributes) will be followed for nested attributes.
 
 ##### Generator Config
 ```yaml
@@ -135,7 +135,7 @@ data_sources:
         "attributes": [
           {
             "name": "pets",
-            "list_nested": {
+            "set_nested": {
               "computed_optional_required": "computed",
               "nested_object": {
                 "attributes": [

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,7 +126,7 @@ data_sources:
 ```
 
 ##### Provider Code Spec output
-```json
+```jsonc
 {
   "datasources": [
     {

--- a/internal/cmd/testdata/petstore3/provider_code_spec.json
+++ b/internal/cmd/testdata/petstore3/provider_code_spec.json
@@ -149,6 +149,86 @@
 								}
 							]
 						}
+					},
+					{
+						"name": "pets",
+						"list_nested": {
+							"computed_optional_required": "computed",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "category",
+										"single_nested": {
+											"computed_optional_required": "computed",
+											"attributes": [
+												{
+													"name": "id",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "name",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												}
+											]
+										}
+									},
+									{
+										"name": "id",
+										"int64": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "name",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "photo_urls",
+										"list": {
+											"computed_optional_required": "computed",
+											"element_type": {
+												"string": {}
+											}
+										}
+									},
+									{
+										"name": "status",
+										"string": {
+											"computed_optional_required": "computed",
+											"description": "pet status in the store"
+										}
+									},
+									{
+										"name": "tags",
+										"list_nested": {
+											"computed_optional_required": "computed",
+											"nested_object": {
+												"attributes": [
+													{
+														"name": "id",
+														"int64": {
+															"computed_optional_required": "computed"
+														}
+													},
+													{
+														"name": "name",
+														"string": {
+															"computed_optional_required": "computed"
+														}
+													}
+												]
+											}
+										}
+									}
+								]
+							}
+						}
 					}
 				]
 			}

--- a/internal/cmd/testdata/petstore3/provider_code_spec.json
+++ b/internal/cmd/testdata/petstore3/provider_code_spec.json
@@ -152,7 +152,7 @@
 					},
 					{
 						"name": "pets",
-						"list_nested": {
+						"set_nested": {
 							"computed_optional_required": "computed",
 							"nested_object": {
 								"attributes": [

--- a/internal/mapper/datasource_mapper.go
+++ b/internal/mapper/datasource_mapper.go
@@ -76,7 +76,10 @@ func generateDataSourceSchema(logger *slog.Logger, name string, dataSource explo
 
 	readResponseAttributes := attrmapper.DataSourceAttributes{}
 	if readResponseSchema.Type == util.OAS_type_array {
-		logger.Debug(fmt.Sprintf("response body is an array, building '%s' collection attribute", name))
+		logger.Debug(fmt.Sprintf("response body is an array, building '%s' set attribute", name))
+
+		// API's generally don't guarantee ordering of results for collection/query responses, default mapping to set
+		readResponseSchema.Format = util.TF_format_set
 
 		collectionAttribute, schemaErr := readResponseSchema.BuildDataSourceAttribute(name, schema.Computed)
 		if schemaErr != nil {

--- a/internal/mapper/datasource_mapper_test.go
+++ b/internal/mapper/datasource_mapper_test.go
@@ -681,7 +681,7 @@ func TestDataSourceMapper_collections(t *testing.T) {
 		readResponseSchema *base.SchemaProxy
 		want               datasource.Attributes
 	}{
-		"data source collection - list nested": {
+		"data source collection - forced set nested": {
 			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
 				Type: []string{"array"},
 				Items: &base.DynamicValue[*base.SchemaProxy, bool]{
@@ -703,7 +703,7 @@ func TestDataSourceMapper_collections(t *testing.T) {
 			want: datasource.Attributes{
 				{
 					Name: "test_datasources",
-					ListNested: &datasource.ListNestedAttribute{
+					SetNested: &datasource.SetNestedAttribute{
 						ComputedOptionalRequired: schema.Computed,
 						NestedObject: datasource.NestedAttributeObject{
 							Attributes: []datasource.Attribute{
@@ -727,7 +727,7 @@ func TestDataSourceMapper_collections(t *testing.T) {
 				},
 			},
 		},
-		"data source collection - set nested": {
+		"data source collection - explicit set nested": {
 			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
 				Type:   []string{"array"},
 				Format: "set",
@@ -774,7 +774,7 @@ func TestDataSourceMapper_collections(t *testing.T) {
 				},
 			},
 		},
-		"data source collection - list with elements": {
+		"data source collection - forced set with elements": {
 			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
 				Type: []string{"array"},
 				Items: &base.DynamicValue[*base.SchemaProxy, bool]{
@@ -786,7 +786,7 @@ func TestDataSourceMapper_collections(t *testing.T) {
 			want: datasource.Attributes{
 				{
 					Name: "test_datasources",
-					List: &datasource.ListAttribute{
+					Set: &datasource.SetAttribute{
 						ComputedOptionalRequired: schema.Computed,
 						ElementType: schema.ElementType{
 							Number: &schema.NumberType{},
@@ -795,7 +795,7 @@ func TestDataSourceMapper_collections(t *testing.T) {
 				},
 			},
 		},
-		"data source collection - set with elements": {
+		"data source collection - explicit set with elements": {
 			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
 				Type:   []string{"array"},
 				Format: "set",

--- a/internal/mapper/datasource_mapper_test.go
+++ b/internal/mapper/datasource_mapper_test.go
@@ -673,3 +673,173 @@ func TestDataSourceMapper_basic_merges(t *testing.T) {
 		})
 	}
 }
+
+func TestDataSourceMapper_collections(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		readResponseSchema *base.SchemaProxy
+		want               datasource.Attributes
+	}{
+		"data source collection - list nested": {
+			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
+				Type: []string{"array"},
+				Items: &base.DynamicValue[*base.SchemaProxy, bool]{
+					A: base.CreateSchemaProxy(&base.Schema{
+						Type: []string{"object"},
+						Properties: map[string]*base.SchemaProxy{
+							"bool_prop": base.CreateSchemaProxy(&base.Schema{
+								Type:        []string{"boolean"},
+								Description: "hey this is a bool!",
+							}),
+							"number_prop": base.CreateSchemaProxy(&base.Schema{
+								Type:        []string{"number"},
+								Description: "hey this is a number!",
+							}),
+						},
+					}),
+				},
+			}),
+			want: datasource.Attributes{
+				{
+					Name: "test_datasources",
+					ListNested: &datasource.ListNestedAttribute{
+						ComputedOptionalRequired: schema.Computed,
+						NestedObject: datasource.NestedAttributeObject{
+							Attributes: []datasource.Attribute{
+								{
+									Name: "bool_prop",
+									Bool: &datasource.BoolAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										Description:              pointer("hey this is a bool!"),
+									},
+								},
+								{
+									Name: "number_prop",
+									Number: &datasource.NumberAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										Description:              pointer("hey this is a number!"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"data source collection - set nested": {
+			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
+				Type:   []string{"array"},
+				Format: "set",
+				Items: &base.DynamicValue[*base.SchemaProxy, bool]{
+					A: base.CreateSchemaProxy(&base.Schema{
+						Type: []string{"object"},
+						Properties: map[string]*base.SchemaProxy{
+							"bool_prop": base.CreateSchemaProxy(&base.Schema{
+								Type:        []string{"boolean"},
+								Description: "hey this is a bool!",
+							}),
+							"number_prop": base.CreateSchemaProxy(&base.Schema{
+								Type:        []string{"number"},
+								Description: "hey this is a number!",
+							}),
+						},
+					}),
+				},
+			}),
+			want: datasource.Attributes{
+				{
+					Name: "test_datasources",
+					SetNested: &datasource.SetNestedAttribute{
+						ComputedOptionalRequired: schema.Computed,
+						NestedObject: datasource.NestedAttributeObject{
+							Attributes: []datasource.Attribute{
+								{
+									Name: "bool_prop",
+									Bool: &datasource.BoolAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										Description:              pointer("hey this is a bool!"),
+									},
+								},
+								{
+									Name: "number_prop",
+									Number: &datasource.NumberAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										Description:              pointer("hey this is a number!"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"data source collection - list with elements": {
+			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
+				Type: []string{"array"},
+				Items: &base.DynamicValue[*base.SchemaProxy, bool]{
+					A: base.CreateSchemaProxy(&base.Schema{
+						Type: []string{"number"},
+					}),
+				},
+			}),
+			want: datasource.Attributes{
+				{
+					Name: "test_datasources",
+					List: &datasource.ListAttribute{
+						ComputedOptionalRequired: schema.Computed,
+						ElementType: schema.ElementType{
+							Number: &schema.NumberType{},
+						},
+					},
+				},
+			},
+		},
+		"data source collection - set with elements": {
+			readResponseSchema: base.CreateSchemaProxy(&base.Schema{
+				Type:   []string{"array"},
+				Format: "set",
+				Items: &base.DynamicValue[*base.SchemaProxy, bool]{
+					A: base.CreateSchemaProxy(&base.Schema{
+						Type: []string{"string"},
+					}),
+				},
+			}),
+			want: datasource.Attributes{
+				{
+					Name: "test_datasources",
+					Set: &datasource.SetAttribute{
+						ComputedOptionalRequired: schema.Computed,
+						ElementType: schema.ElementType{
+							String: &schema.StringType{},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := mapper.NewDataSourceMapper(map[string]explorer.DataSource{
+				"test_datasources": {
+					ReadOp: createTestReadOp(testCase.readResponseSchema, nil),
+				},
+			}, config.Config{})
+			got, err := mapper.MapToIR(slog.Default())
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if len(got) != 1 {
+				t.Fatalf("expected only one DataSource, got: %d", len(got))
+			}
+
+			if diff := cmp.Diff(got[0].Schema.Attributes, testCase.want); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/mapper/oas/collection.go
+++ b/internal/mapper/oas/collection.go
@@ -32,7 +32,7 @@ func (s *OASSchema) BuildCollectionResource(name string, computability schema.Co
 			return nil, s.NestSchemaError(err, name)
 		}
 
-		if s.Schema.Format == util.TF_format_set {
+		if s.Format == util.TF_format_set {
 			result := &attrmapper.ResourceSetNestedAttribute{
 				Name: name,
 				NestedObject: attrmapper.ResourceNestedAttributeObject{
@@ -76,7 +76,7 @@ func (s *OASSchema) BuildCollectionResource(name string, computability schema.Co
 		return nil, s.NestSchemaError(err, name)
 	}
 
-	if s.Schema.Format == util.TF_format_set {
+	if s.Format == util.TF_format_set {
 		result := &attrmapper.ResourceSetAttribute{
 			Name: name,
 			SetAttribute: resource.SetAttribute{
@@ -128,7 +128,7 @@ func (s *OASSchema) BuildCollectionDataSource(name string, computability schema.
 			return nil, s.NestSchemaError(err, name)
 		}
 
-		if s.Schema.Format == util.TF_format_set {
+		if s.Format == util.TF_format_set {
 
 			result := &attrmapper.DataSourceSetNestedAttribute{
 				Name: name,
@@ -173,7 +173,7 @@ func (s *OASSchema) BuildCollectionDataSource(name string, computability schema.
 		return nil, s.NestSchemaError(err, name)
 	}
 
-	if s.Schema.Format == util.TF_format_set {
+	if s.Format == util.TF_format_set {
 
 		result := &attrmapper.DataSourceSetAttribute{
 			Name: name,
@@ -226,7 +226,7 @@ func (s *OASSchema) BuildCollectionProvider(name string, optionalOrRequired sche
 			return nil, s.NestSchemaError(err, name)
 		}
 
-		if s.Schema.Format == util.TF_format_set {
+		if s.Format == util.TF_format_set {
 
 			result := &attrmapper.ProviderSetNestedAttribute{
 				Name: name,
@@ -265,7 +265,7 @@ func (s *OASSchema) BuildCollectionProvider(name string, optionalOrRequired sche
 		return nil, s.NestSchemaError(err, name)
 	}
 
-	if s.Schema.Format == util.TF_format_set {
+	if s.Format == util.TF_format_set {
 		result := &attrmapper.ProviderSetAttribute{
 			Name: name,
 			SetAttribute: provider.SetAttribute{
@@ -308,7 +308,7 @@ func (s *OASSchema) BuildCollectionElementType() (schema.ElementType, *SchemaErr
 		return schema.ElementType{}, err
 	}
 
-	if s.Schema.Format == util.TF_format_set {
+	if s.Format == util.TF_format_set {
 		return schema.ElementType{
 			Set: &schema.SetType{
 				ElementType: elemType,


### PR DESCRIPTION
Closes #16 

This PR introduces logic to detect a response body array for a data source, then map to a single collection attribute. This is then merged with query/path parameters as usual.