### PR TITLE
Add support for objects with `properties` that omit the `type` field 

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20231020-170209.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20231020-170209.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Schemas that have the `properties` keyword defined with no type will now default
+  to `object`
+time: 2023-10-20T17:02:09.205328-04:00
+custom:
+  Issue: "79"

--- a/internal/cmd/testdata/edgecase/generator_config.yml
+++ b/internal/cmd/testdata/edgecase/generator_config.yml
@@ -31,3 +31,7 @@ data_sources:
     read:
       path: /map_test
       method: GET
+  obj_no_type:
+    read:
+      path: /obj_no_type
+      method: GET

--- a/internal/cmd/testdata/edgecase/openapi_spec.yml
+++ b/internal/cmd/testdata/edgecase/openapi_spec.yml
@@ -4,6 +4,24 @@ info:
   description: This is a fake API spec that was built to test some of the less common API schema structures and their mapping in the OpenAPI to Framework code generator
   version: 1.0.0
 paths:
+  /obj_no_type:
+    get:
+      summary: Test for objects that have no types!
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  string_prop:
+                    description: String inside an object!
+                    type: string
+                  nested_obj:
+                    properties:
+                      bool_prop:
+                        description: Bool inside a nested object!
+                        type: boolean
   /nested_collections:
     get:
       summary: Test for nested collections (list within a list, set within a list, map within a list)

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -121,6 +121,35 @@
 			}
 		},
 		{
+			"name": "obj_no_type",
+			"schema": {
+				"attributes": [
+					{
+						"name": "nested_obj",
+						"single_nested": {
+							"computed_optional_required": "computed",
+							"attributes": [
+								{
+									"name": "bool_prop",
+									"bool": {
+										"computed_optional_required": "computed",
+										"description": "Bool inside a nested object!"
+									}
+								}
+							]
+						}
+					},
+					{
+						"name": "string_prop",
+						"string": {
+							"computed_optional_required": "computed",
+							"description": "String inside an object!"
+						}
+					}
+				]
+			}
+		},
+		{
 			"name": "set_test",
 			"schema": {
 				"attributes": [

--- a/internal/mapper/oas/build.go
+++ b/internal/mapper/oas/build.go
@@ -224,6 +224,12 @@ func getMultiTypeSchema(proxyOne *base.SchemaProxy, proxyTwo *base.SchemaProxy) 
 func retrieveType(schema *base.Schema) (string, *SchemaError) {
 	switch len(schema.Type) {
 	case 0:
+		// Properties are only valid applying to objects, it's possible tools might omit the type
+		// https://github.com/hashicorp/terraform-plugin-codegen-openapi/issues/79
+		if len(schema.Properties) > 0 {
+			return util.OAS_type_object, nil
+		}
+
 		return "", SchemaErrorFromProxy(errors.New("no 'type' array or supported allOf, oneOf, anyOf constraint - attribute cannot be created"), schema.ParentProxy)
 	case 1:
 		return schema.Type[0], nil


### PR DESCRIPTION
Closes #79 

[JSON schema's specification](https://json-schema.org/draft/2020-12/json-schema-core#name-properties) mentions that the `properties` keyword applies to `object`. Some tools like [getkin/kin-openapi](https://github.com/getkin/kin-openapi) may omit that type.

If a schema contains `properties` but doesn't define a type, we can return `object` as the default.

### Notes
I believe based on this specification that `additionalProperties` aka `maps` should also behave this way, but we'll wait for an issue before adding that 🙂 