### PR TITLE
Add `schema.ignores` option to allow excluding attributes from mapping

### DIFF
--- a/.changes/unreleased/FEATURES-20231026-162053.yaml
+++ b/.changes/unreleased/FEATURES-20231026-162053.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: Added schema.ignores option to generator config for resources, data sources,
+  and providers. Allows excluding attributes from OAS mapping
+time: 2023-10-26T16:20:53.404821-04:00
+custom:
+  Issue: "81"

--- a/internal/cmd/testdata/edgecase/generator_config.yml
+++ b/internal/cmd/testdata/edgecase/generator_config.yml
@@ -1,6 +1,9 @@
 provider:
   name: edgecase
   schema_ref: '#/components/schemas/edgecase_provider'
+  ignores:
+    - triple_nested_map.ignore_me_1
+    - triple_nested_map.obj_prop.ignore_me_2
 
 resources:
   set_test:

--- a/internal/cmd/testdata/edgecase/generator_config.yml
+++ b/internal/cmd/testdata/edgecase/generator_config.yml
@@ -23,6 +23,10 @@ data_sources:
     read:
       path: /nested_collections
       method: GET
+    schema:
+      ignores:
+        - triple_nested_map.ignore_me_1
+        - triple_nested_map.obj_prop.ignore_me_2
   set_test:
     read:
       path: /set_test

--- a/internal/cmd/testdata/edgecase/generator_config.yml
+++ b/internal/cmd/testdata/edgecase/generator_config.yml
@@ -13,6 +13,10 @@ resources:
     read:
       path: /set_test
       method: GET
+    schema:
+      ignores:
+        - setnested_prop.string_prop
+
   map_test:
     create:
       path: /map_test
@@ -30,6 +34,7 @@ data_sources:
       ignores:
         - triple_nested_map.ignore_me_1
         - triple_nested_map.obj_prop.ignore_me_2
+
   set_test:
     read:
       path: /set_test

--- a/internal/cmd/testdata/edgecase/openapi_spec.yml
+++ b/internal/cmd/testdata/edgecase/openapi_spec.yml
@@ -175,6 +175,19 @@ components:
               bool_prop:
                 description: Bool inside a map!
                 type: boolean
+              ignore_me_1:
+                description: This property will be ignored!
+                type: string
+              obj_prop:
+                description: Object inside a map!
+                type: object
+                properties:
+                  number_prop:
+                    description: Number inside a map!
+                    type: number
+                  ignore_me_2:
+                    description: This property will be ignored!
+                    type: string
     setnested_schema:
       description: This is a set with a nested object
       type: array

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -104,6 +104,25 @@
 															"bool": {}
 														},
 														{
+															"name": "ignore_me_1",
+															"string": {}
+														},
+														{
+															"name": "obj_prop",
+															"object": {
+																"attribute_types": [
+																	{
+																		"name": "ignore_me_2",
+																		"string": {}
+																	},
+																	{
+																		"name": "number_prop",
+																		"number": {}
+																	}
+																]
+															}
+														},
+														{
 															"name": "string_prop",
 															"string": {}
 														}
@@ -224,6 +243,25 @@
 													{
 														"name": "bool_prop",
 														"bool": {}
+													},
+													{
+														"name": "ignore_me_1",
+														"string": {}
+													},
+													{
+														"name": "obj_prop",
+														"object": {
+															"attribute_types": [
+																{
+																	"name": "ignore_me_2",
+																	"string": {}
+																},
+																{
+																	"name": "number_prop",
+																	"number": {}
+																}
+															]
+														}
 													},
 													{
 														"name": "string_prop",

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -104,17 +104,9 @@
 															"bool": {}
 														},
 														{
-															"name": "ignore_me_1",
-															"string": {}
-														},
-														{
 															"name": "obj_prop",
 															"object": {
 																"attribute_types": [
-																	{
-																		"name": "ignore_me_2",
-																		"string": {}
-																	},
 																	{
 																		"name": "number_prop",
 																		"number": {}

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -237,17 +237,9 @@
 														"bool": {}
 													},
 													{
-														"name": "ignore_me_1",
-														"string": {}
-													},
-													{
 														"name": "obj_prop",
 														"object": {
 															"attribute_types": [
-																{
-																	"name": "ignore_me_2",
-																	"string": {}
-																},
 																{
 																	"name": "number_prop",
 																	"number": {}
@@ -340,13 +332,6 @@
 										"bool": {
 											"computed_optional_required": "computed_optional",
 											"description": "Bool inside a set!"
-										}
-									},
-									{
-										"name": "string_prop",
-										"string": {
-											"computed_optional_required": "computed_optional",
-											"description": "String inside a set!"
 										}
 									}
 								]

--- a/internal/cmd/testdata/github/generator_config.yml
+++ b/internal/cmd/testdata/github/generator_config.yml
@@ -27,6 +27,10 @@ data_sources:
     read:
       path: /gists/{gist_id}
       method: GET
+    schema:
+      ignores:
+        - fork_of.forks
+        - fork_of.history
 
   repository:
     read:

--- a/internal/cmd/testdata/github/generator_config.yml
+++ b/internal/cmd/testdata/github/generator_config.yml
@@ -31,6 +31,8 @@ data_sources:
       ignores:
         - fork_of.forks
         - fork_of.history
+        - fork_of.files.language
+        - forks.user.plan.collaborators
 
   repository:
     read:

--- a/internal/cmd/testdata/github/generator_config.yml
+++ b/internal/cmd/testdata/github/generator_config.yml
@@ -23,6 +23,11 @@ resources:
           repo: name
 
 data_sources:
+  gists:
+    read:
+      path: /gists/{gist_id}
+      method: GET
+
   repository:
     read:
       path: /repos/{owner}/{repo}

--- a/internal/cmd/testdata/github/provider_code_spec.json
+++ b/internal/cmd/testdata/github/provider_code_spec.json
@@ -141,12 +141,6 @@
 													}
 												},
 												{
-													"name": "language",
-													"string": {
-														"computed_optional_required": "computed"
-													}
-												},
-												{
 													"name": "raw_url",
 													"string": {
 														"computed_optional_required": "computed"
@@ -686,12 +680,6 @@
 													"single_nested": {
 														"computed_optional_required": "computed",
 														"attributes": [
-															{
-																"name": "collaborators",
-																"int64": {
-																	"computed_optional_required": "computed"
-																}
-															},
 															{
 																"name": "name",
 																"string": {

--- a/internal/cmd/testdata/github/provider_code_spec.json
+++ b/internal/cmd/testdata/github/provider_code_spec.json
@@ -1,6 +1,1206 @@
 {
 	"datasources": [
 		{
+			"name": "gists",
+			"schema": {
+				"attributes": [
+					{
+						"name": "gist_id",
+						"string": {
+							"computed_optional_required": "required",
+							"description": "The unique identifier of the gist."
+						}
+					},
+					{
+						"name": "comments",
+						"int64": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "comments_url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "commits_url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "created_at",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "description",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "files",
+						"map_nested": {
+							"computed_optional_required": "computed",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "content",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "filename",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "language",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "raw_url",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "size",
+										"int64": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "truncated",
+										"bool": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "type",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									}
+								]
+							}
+						}
+					},
+					{
+						"name": "fork_of",
+						"single_nested": {
+							"computed_optional_required": "computed",
+							"attributes": [
+								{
+									"name": "comments",
+									"int64": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "comments_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "commits_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "created_at",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "description",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "files",
+									"map_nested": {
+										"computed_optional_required": "computed",
+										"nested_object": {
+											"attributes": [
+												{
+													"name": "filename",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "language",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "raw_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "size",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "type",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												}
+											]
+										}
+									}
+								},
+								{
+									"name": "forks_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "git_pull_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "git_push_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "html_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "id",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "node_id",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "owner",
+									"single_nested": {
+										"computed_optional_required": "computed",
+										"attributes": [
+											{
+												"name": "avatar_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "email",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "events_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "followers_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "following_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "gists_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "gravatar_id",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "html_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "id",
+												"int64": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "login",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "name",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "node_id",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "organizations_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "received_events_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "repos_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "site_admin",
+												"bool": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "starred_at",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "starred_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "subscriptions_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "type",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											}
+										],
+										"description": "A GitHub user."
+									}
+								},
+								{
+									"name": "public",
+									"bool": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "truncated",
+									"bool": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "updated_at",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "user",
+									"single_nested": {
+										"computed_optional_required": "computed",
+										"attributes": [
+											{
+												"name": "avatar_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "email",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "events_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "followers_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "following_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "gists_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "gravatar_id",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "html_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "id",
+												"int64": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "login",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "name",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "node_id",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "organizations_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "received_events_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "repos_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "site_admin",
+												"bool": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "starred_at",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "starred_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "subscriptions_url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "type",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											},
+											{
+												"name": "url",
+												"string": {
+													"computed_optional_required": "computed"
+												}
+											}
+										],
+										"description": "A GitHub user."
+									}
+								}
+							],
+							"description": "Gist"
+						}
+					},
+					{
+						"name": "forks",
+						"list_nested": {
+							"computed_optional_required": "computed",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "created_at",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "id",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "updated_at",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "url",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "user",
+										"single_nested": {
+											"computed_optional_required": "computed",
+											"attributes": [
+												{
+													"name": "avatar_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "bio",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "blog",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "collaborators",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "company",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "created_at",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "disk_usage",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "email",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "events_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "followers",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "followers_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "following",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "following_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "gists_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "gravatar_id",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "hireable",
+													"bool": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "html_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "id",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "location",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "login",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "name",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "node_id",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "organizations_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "owned_private_repos",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "plan",
+													"single_nested": {
+														"computed_optional_required": "computed",
+														"attributes": [
+															{
+																"name": "collaborators",
+																"int64": {
+																	"computed_optional_required": "computed"
+																}
+															},
+															{
+																"name": "name",
+																"string": {
+																	"computed_optional_required": "computed"
+																}
+															},
+															{
+																"name": "private_repos",
+																"int64": {
+																	"computed_optional_required": "computed"
+																}
+															},
+															{
+																"name": "space",
+																"int64": {
+																	"computed_optional_required": "computed"
+																}
+															}
+														]
+													}
+												},
+												{
+													"name": "private_gists",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "public_gists",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "public_repos",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "received_events_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "repos_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "site_admin",
+													"bool": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "starred_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "subscriptions_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "suspended_at",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "total_private_repos",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "twitter_username",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "type",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "updated_at",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												}
+											],
+											"description": "Public User"
+										}
+									}
+								]
+							},
+							"deprecation_message": "This attribute is deprecated."
+						}
+					},
+					{
+						"name": "forks_url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "git_pull_url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "git_push_url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "history",
+						"list_nested": {
+							"computed_optional_required": "computed",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "change_status",
+										"single_nested": {
+											"computed_optional_required": "computed",
+											"attributes": [
+												{
+													"name": "additions",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "deletions",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "total",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												}
+											]
+										}
+									},
+									{
+										"name": "committed_at",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "url",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									},
+									{
+										"name": "user",
+										"single_nested": {
+											"computed_optional_required": "computed",
+											"attributes": [
+												{
+													"name": "avatar_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "email",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "events_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "followers_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "following_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "gists_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "gravatar_id",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "html_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "id",
+													"int64": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "login",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "name",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "node_id",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "organizations_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "received_events_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "repos_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "site_admin",
+													"bool": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "starred_at",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "starred_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "subscriptions_url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "type",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												},
+												{
+													"name": "url",
+													"string": {
+														"computed_optional_required": "computed"
+													}
+												}
+											],
+											"description": "A GitHub user."
+										}
+									},
+									{
+										"name": "version",
+										"string": {
+											"computed_optional_required": "computed"
+										}
+									}
+								]
+							},
+							"deprecation_message": "This attribute is deprecated."
+						}
+					},
+					{
+						"name": "html_url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "id",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "node_id",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "owner",
+						"single_nested": {
+							"computed_optional_required": "computed",
+							"attributes": [
+								{
+									"name": "avatar_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "email",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "events_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "followers_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "following_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "gists_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "gravatar_id",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "html_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "id",
+									"int64": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "login",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "name",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "node_id",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "organizations_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "received_events_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "repos_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "site_admin",
+									"bool": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "starred_at",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "starred_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "subscriptions_url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "type",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								},
+								{
+									"name": "url",
+									"string": {
+										"computed_optional_required": "computed"
+									}
+								}
+							],
+							"description": "A GitHub user."
+						}
+					},
+					{
+						"name": "public",
+						"bool": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "truncated",
+						"bool": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "updated_at",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "url",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					},
+					{
+						"name": "user",
+						"string": {
+							"computed_optional_required": "computed"
+						}
+					}
+				]
+			}
+		},
+		{
 			"name": "repository",
 			"schema": {
 				"attributes": [

--- a/internal/cmd/testdata/petstore3/generator_config.yml
+++ b/internal/cmd/testdata/petstore3/generator_config.yml
@@ -54,6 +54,9 @@ resources:
     read:
       path: /user/{username}
       method: GET
+    schema:
+      ignores:
+        - username
 
 data_sources:
   pet:

--- a/internal/cmd/testdata/petstore3/generator_config.yml
+++ b/internal/cmd/testdata/petstore3/generator_config.yml
@@ -76,6 +76,9 @@ data_sources:
     read:
       path: /pet/findByStatus
       method: GET
+    schema:
+      ignores:
+        - status
 
   order:
     read:

--- a/internal/cmd/testdata/petstore3/provider_code_spec.json
+++ b/internal/cmd/testdata/petstore3/provider_code_spec.json
@@ -132,25 +132,6 @@
 			"schema": {
 				"attributes": [
 					{
-						"name": "status",
-						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "Status values that need to be considered for filter",
-							"validators": [
-								{
-									"custom": {
-										"imports": [
-											{
-												"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-											}
-										],
-										"schema_definition": "stringvalidator.OneOf(\n\"available\",\n\"pending\",\n\"sold\",\n)"
-									}
-								}
-							]
-						}
-					},
-					{
 						"name": "pets",
 						"set_nested": {
 							"computed_optional_required": "computed",
@@ -195,13 +176,6 @@
 											"element_type": {
 												"string": {}
 											}
-										}
-									},
-									{
-										"name": "status",
-										"string": {
-											"computed_optional_required": "computed",
-											"description": "pet status in the store"
 										}
 									},
 									{

--- a/internal/cmd/testdata/petstore3/provider_code_spec.json
+++ b/internal/cmd/testdata/petstore3/provider_code_spec.json
@@ -409,13 +409,6 @@
 							"computed_optional_required": "computed_optional",
 							"description": "User Status"
 						}
-					},
-					{
-						"name": "username",
-						"string": {
-							"computed_optional_required": "computed_optional",
-							"description": "The name that needs to be fetched. Use user1 for testing. "
-						}
 					}
 				]
 			}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -31,6 +31,10 @@ type Config struct {
 type Provider struct {
 	Name      string `yaml:"name"`
 	SchemaRef string `yaml:"schema_ref"`
+
+	// TODO: At some point, this should probably be refactored to work with the SchemaOptions struct
+	// Ignores are a slice of strings, representing an attribute location to ignore during mapping (dot-separated for nested attributes).
+	Ignores []string `yaml:"ignores"`
 }
 
 // Resource generator config section.

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -133,16 +133,24 @@ func (c Config) Validate() error {
 }
 
 func (p Provider) Validate() error {
+	var result error
+
 	if p.Name == "" {
-		return errors.New("must have a 'name' property")
+		result = errors.Join(result, errors.New("must have a 'name' property"))
 	}
 
 	// All schema refs must be a local, file, or http resolve type
 	if p.SchemaRef != "" && index.DetermineReferenceResolveType(p.SchemaRef) < 0 {
-		return errors.New("'schema_ref' must be a valid JSON schema reference")
+		result = errors.Join(result, errors.New("'schema_ref' must be a valid JSON schema reference"))
 	}
 
-	return nil
+	for _, ignore := range p.Ignores {
+		if !attributeLocationRegex.MatchString(ignore) {
+			result = errors.Join(result, fmt.Errorf("invalid item for ignores: %q - must be dot-separated string", ignore))
+		}
+	}
+
+	return result
 }
 
 func (r Resource) Validate() error {
@@ -226,6 +234,12 @@ func (s *SchemaOptions) Validate() error {
 	err := s.AttributeOptions.Validate()
 	if err != nil {
 		result = errors.Join(result, fmt.Errorf("invalid attributes: %w", err))
+	}
+
+	for _, ignore := range s.Ignores {
+		if !attributeLocationRegex.MatchString(ignore) {
+			result = errors.Join(result, fmt.Errorf("invalid item for ignores: %q - must be dot-separated string", ignore))
+		}
 	}
 
 	return result

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -62,6 +62,8 @@ type OpenApiSpecLocation struct {
 
 // SchemaOptions generator config section. This section contains options for modifying the output of the generator.
 type SchemaOptions struct {
+	// Ignores are a slice of strings, representing an attribute location to ignore during mapping (dot-separated for nested attributes).
+	Ignores          []string         `yaml:"ignores"`
 	AttributeOptions AttributeOptions `yaml:"attributes"`
 }
 

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -71,6 +71,23 @@ resources:
           "hey.there.nested.thing":
             description: Deeply nested property 'thing'`,
 		},
+		"valid resource with ignores": {
+			input: `
+provider:
+  name: example
+
+resources:
+  thing:
+    create:
+      path: /example/path/to/things
+      method: POST
+    read:
+      path: /example/path/to/thing/{id}
+      method: GET
+    schema:
+      ignores:
+        - valid.ignore.combo`,
+		},
 		"valid single data source": {
 			input: `
 provider:
@@ -116,6 +133,20 @@ data_sources:
             description: Here is a test description for the 'there' property in 'hey'
           "hey.there.nested.thing":
             description: Deeply nested property 'thing'`,
+		},
+		"valid data source with ignores": {
+			input: `
+provider:
+  name: example
+
+data_sources:
+  thing:
+    read:
+      path: /example/path/to/thing/{id}
+      method: GET
+    schema:
+      ignores:
+        - valid.ignore.combo`,
 		},
 		"valid combo of resources and data sources": {
 			input: `
@@ -194,6 +225,20 @@ data_sources:
       path: /example/path/to/thing/{id}
       method: GET`,
 			expectedErrRegex: `provider 'schema_ref' must be a valid JSON schema reference`,
+		},
+		"provider - invalid ignore item": {
+			input: `
+provider:
+  name: example
+  ignores:
+    - .invalid.ignore.
+
+data_sources:
+  thing_one:
+    read:
+      path: /example/path/to/thing/{id}
+      method: GET`,
+			expectedErrRegex: `invalid item for ignores: \".invalid.ignore.\"`,
 		},
 		"at least one resource or data source required": {
 			input: `
@@ -333,6 +378,24 @@ resources:
             description: Here is a test description for the 'hey' property`,
 			expectedErrRegex: `invalid key for override: \".hey\"`,
 		},
+		"resource - invalid ignore item": {
+			input: `
+provider:
+  name: example
+
+resources:
+  thing_one:
+    create:
+      path: /example/path/to/things
+      method: POST
+    read:
+      path: /example/path/to/thing/{id}
+      method: GET
+    schema:
+      ignores:
+        - .invalid.ignore.`,
+			expectedErrRegex: `invalid item for ignores: \".invalid.ignore.\"`,
+		},
 		"data source - read required": {
 			input: `
 provider:
@@ -380,6 +443,21 @@ data_sources:
           "hey.":
             description: Here is a test description for the 'hey' property`,
 			expectedErrRegex: `invalid key for override: \"hey.\"`,
+		},
+		"data source - invalid ignore item": {
+			input: `
+provider:
+  name: example
+
+data_sources:
+  thing_one:
+    read:
+      path: /example/path/to/thing/{id}
+      method: GET
+    schema:
+      ignores:
+        - .invalid.ignore.`,
+			expectedErrRegex: `invalid item for ignores: \".invalid.ignore.\"`,
 		},
 	}
 	for name, testCase := range testCases {

--- a/internal/explorer/config_explorer.go
+++ b/internal/explorer/config_explorer.go
@@ -49,6 +49,7 @@ func (e configExplorer) FindProvider() (Provider, error) {
 		return Provider{}, fmt.Errorf("error extracting provider schema from ref: %w", err)
 	}
 	foundProvider.SchemaProxy = schemaProxy
+	foundProvider.Ignores = e.config.Provider.Ignores
 
 	return foundProvider, nil
 }

--- a/internal/explorer/config_explorer.go
+++ b/internal/explorer/config_explorer.go
@@ -170,6 +170,7 @@ func extractSchemaProxy(document high.Document, componentRef string) (*highbase.
 
 func extractSchemaOptions(cfgSchemaOpts config.SchemaOptions) SchemaOptions {
 	return SchemaOptions{
+		Ignores: cfgSchemaOpts.Ignores,
 		AttributeOptions: AttributeOptions{
 			Aliases:   cfgSchemaOpts.AttributeOptions.Aliases,
 			Overrides: extractOverrides(cfgSchemaOpts.AttributeOptions.Overrides),

--- a/internal/explorer/config_explorer_test.go
+++ b/internal/explorer/config_explorer_test.go
@@ -261,6 +261,7 @@ func Test_ConfigExplorer_FindResources(t *testing.T) {
 							Method: "GET",
 						},
 						SchemaOptions: config.SchemaOptions{
+							Ignores: []string{"ignore1.abc", "ignore2.def"},
 							AttributeOptions: config.AttributeOptions{
 								Aliases: map[string]string{
 									"otherId": "id",
@@ -300,6 +301,7 @@ func Test_ConfigExplorer_FindResources(t *testing.T) {
 						OperationId: "read_resource",
 					},
 					SchemaOptions: explorer.SchemaOptions{
+						Ignores: []string{"ignore1.abc", "ignore2.def"},
 						AttributeOptions: explorer.AttributeOptions{
 							Aliases: map[string]string{
 								"otherId": "id",
@@ -463,6 +465,7 @@ func Test_ConfigExplorer_FindDataSources(t *testing.T) {
 							Method: "GET",
 						},
 						SchemaOptions: config.SchemaOptions{
+							Ignores: []string{"ignore1.abc", "ignore2.def"},
 							AttributeOptions: config.AttributeOptions{
 								Aliases: map[string]string{
 									"otherId": "id",
@@ -492,6 +495,7 @@ func Test_ConfigExplorer_FindDataSources(t *testing.T) {
 						OperationId: "read_resource",
 					},
 					SchemaOptions: explorer.SchemaOptions{
+						Ignores: []string{"ignore1.abc", "ignore2.def"},
 						AttributeOptions: explorer.AttributeOptions{
 							Aliases: map[string]string{
 								"otherId": "id",

--- a/internal/explorer/explorer.go
+++ b/internal/explorer/explorer.go
@@ -34,6 +34,7 @@ type DataSource struct {
 type Provider struct {
 	Name        string
 	SchemaProxy *base.SchemaProxy
+	Ignores     []string
 }
 
 type SchemaOptions struct {

--- a/internal/explorer/explorer.go
+++ b/internal/explorer/explorer.go
@@ -37,6 +37,7 @@ type Provider struct {
 }
 
 type SchemaOptions struct {
+	Ignores          []string
 	AttributeOptions AttributeOptions
 }
 

--- a/internal/mapper/datasource_mapper.go
+++ b/internal/mapper/datasource_mapper.go
@@ -138,7 +138,6 @@ func generateDataSourceSchema(logger *slog.Logger, name string, dataSource explo
 			}
 
 			if s.IsPropertyIgnored(paramName) {
-				// TODO: produce a log?
 				continue
 			}
 

--- a/internal/mapper/oas/attribute.go
+++ b/internal/mapper/oas/attribute.go
@@ -66,14 +66,21 @@ func (s *OASSchema) BuildResourceAttribute(name string, computability schema.Com
 func (s *OASSchema) BuildDataSourceAttributes() (attrmapper.DataSourceAttributes, *SchemaError) {
 	objectAttributes := attrmapper.DataSourceAttributes{}
 
-	// TODO: throw error if it's not an object?
-
 	// Guarantee the order of processing
 	propertyNames := util.SortedKeys(s.Schema.Properties)
 	for _, name := range propertyNames {
 
+		if s.IsPropertyIgnored(name) {
+			// TODO: produce a log?
+			continue
+		}
+
 		pProxy := s.Schema.Properties[name]
-		pSchema, err := BuildSchema(pProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+		schemaOpts := SchemaOpts{
+			Ignores: s.GetIgnoresForNested(name),
+		}
+
+		pSchema, err := BuildSchema(pProxy, schemaOpts, s.GlobalSchemaOpts)
 		if err != nil {
 			return nil, s.NestSchemaError(err, name)
 		}

--- a/internal/mapper/oas/attribute.go
+++ b/internal/mapper/oas/attribute.go
@@ -19,7 +19,6 @@ func (s *OASSchema) BuildResourceAttributes() (attrmapper.ResourceAttributes, *S
 	for _, name := range propertyNames {
 
 		if s.IsPropertyIgnored(name) {
-			// TODO: produce a log?
 			continue
 		}
 
@@ -78,7 +77,6 @@ func (s *OASSchema) BuildDataSourceAttributes() (attrmapper.DataSourceAttributes
 	for _, name := range propertyNames {
 
 		if s.IsPropertyIgnored(name) {
-			// TODO: produce a log?
 			continue
 		}
 
@@ -137,7 +135,6 @@ func (s *OASSchema) BuildProviderAttributes() (attrmapper.ProviderAttributes, *S
 	for _, name := range propertyNames {
 
 		if s.IsPropertyIgnored(name) {
-			// TODO: produce a log?
 			continue
 		}
 

--- a/internal/mapper/oas/attribute.go
+++ b/internal/mapper/oas/attribute.go
@@ -14,14 +14,21 @@ import (
 func (s *OASSchema) BuildResourceAttributes() (attrmapper.ResourceAttributes, *SchemaError) {
 	objectAttributes := attrmapper.ResourceAttributes{}
 
-	// TODO: throw error if it's not an object?
-
 	// Guarantee the order of processing
 	propertyNames := util.SortedKeys(s.Schema.Properties)
 	for _, name := range propertyNames {
 
+		if s.IsPropertyIgnored(name) {
+			// TODO: produce a log?
+			continue
+		}
+
 		pProxy := s.Schema.Properties[name]
-		pSchema, err := BuildSchema(pProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+		schemaOpts := SchemaOpts{
+			Ignores: s.GetIgnoresForNested(name),
+		}
+
+		pSchema, err := BuildSchema(pProxy, schemaOpts, s.GlobalSchemaOpts)
 		if err != nil {
 			return nil, s.NestSchemaError(err, name)
 		}
@@ -125,14 +132,21 @@ func (s *OASSchema) BuildDataSourceAttribute(name string, computability schema.C
 func (s *OASSchema) BuildProviderAttributes() (attrmapper.ProviderAttributes, *SchemaError) {
 	objectAttributes := attrmapper.ProviderAttributes{}
 
-	// TODO: throw error if it's not an object?
-
 	// Guarantee the order of processing
 	propertyNames := util.SortedKeys(s.Schema.Properties)
 	for _, name := range propertyNames {
 
+		if s.IsPropertyIgnored(name) {
+			// TODO: produce a log?
+			continue
+		}
+
 		pProxy := s.Schema.Properties[name]
-		pSchema, err := BuildSchema(pProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+		schemaOpts := SchemaOpts{
+			Ignores: s.GetIgnoresForNested(name),
+		}
+
+		pSchema, err := BuildSchema(pProxy, schemaOpts, s.GlobalSchemaOpts)
 		if err != nil {
 			return nil, s.NestSchemaError(err, name)
 		}

--- a/internal/mapper/oas/collection.go
+++ b/internal/mapper/oas/collection.go
@@ -20,7 +20,10 @@ func (s *OASSchema) BuildCollectionResource(name string, computability schema.Co
 		return nil, s.SchemaErrorFromProperty(errors.New("invalid array items property, doesn't have a schema"), name)
 	}
 
-	itemSchema, err := BuildSchema(s.Schema.Items.A, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	itemSchema, err := BuildSchema(s.Schema.Items.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -217,7 +220,10 @@ func (s *OASSchema) BuildCollectionProvider(name string, optionalOrRequired sche
 		return nil, s.SchemaErrorFromProperty(errors.New("invalid array items property, doesn't have a schema"), name)
 	}
 
-	itemSchema, err := BuildSchema(s.Schema.Items.A, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	itemSchema, err := BuildSchema(s.Schema.Items.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}

--- a/internal/mapper/oas/collection.go
+++ b/internal/mapper/oas/collection.go
@@ -116,7 +116,10 @@ func (s *OASSchema) BuildCollectionDataSource(name string, computability schema.
 		return nil, s.SchemaErrorFromProperty(errors.New("invalid array items property, doesn't have a schema"), name)
 	}
 
-	itemSchema, err := BuildSchema(s.Schema.Items.A, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	itemSchema, err := BuildSchema(s.Schema.Items.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -298,7 +301,11 @@ func (s *OASSchema) BuildCollectionElementType() (schema.ElementType, *SchemaErr
 	if !s.Schema.Items.IsA() {
 		return schema.ElementType{}, SchemaErrorFromNode(errors.New("invalid array type for nested elem array, doesn't have a schema"), s.Schema, Items)
 	}
-	itemSchema, err := BuildSchema(s.Schema.Items.A, SchemaOpts{}, s.GlobalSchemaOpts)
+
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	itemSchema, err := BuildSchema(s.Schema.Items.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return schema.ElementType{}, err
 	}

--- a/internal/mapper/oas/map.go
+++ b/internal/mapper/oas/map.go
@@ -83,7 +83,10 @@ func (s *OASSchema) BuildMapDataSource(name string, computability schema.Compute
 		return nil, s.SchemaErrorFromProperty(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), name)
 	}
 
-	mapSchema, err := BuildSchema(mapSchemaProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -197,7 +200,10 @@ func (s *OASSchema) BuildMapElementType() (schema.ElementType, *SchemaError) {
 		return schema.ElementType{}, SchemaErrorFromNode(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), s.Schema, AdditionalProperties)
 	}
 
-	mapSchema, err := BuildSchema(mapSchemaProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return schema.ElementType{}, err
 	}

--- a/internal/mapper/oas/map.go
+++ b/internal/mapper/oas/map.go
@@ -24,7 +24,10 @@ func (s *OASSchema) BuildMapResource(name string, computability schema.ComputedO
 		return nil, s.SchemaErrorFromProperty(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), name)
 	}
 
-	mapSchema, err := BuildSchema(mapSchemaProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -146,7 +149,10 @@ func (s *OASSchema) BuildMapProvider(name string, optionalOrRequired schema.Opti
 		return nil, s.SchemaErrorFromProperty(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), name)
 	}
 
-	mapSchema, err := BuildSchema(mapSchemaProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+	schemaOpts := SchemaOpts{
+		Ignores: s.SchemaOpts.Ignores,
+	}
+	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}

--- a/internal/mapper/oas/object.go
+++ b/internal/mapper/oas/object.go
@@ -14,9 +14,17 @@ func (s *OASSchema) BuildObjectElementType() (schema.ElementType, *SchemaError) 
 	// Guarantee the order of processing
 	propertyNames := util.SortedKeys(s.Schema.Properties)
 	for _, name := range propertyNames {
-		pProxy := s.Schema.Properties[name]
+		if s.IsPropertyIgnored(name) {
+			// TODO: produce a log?
+			continue
+		}
 
-		pSchema, err := BuildSchema(pProxy, SchemaOpts{}, s.GlobalSchemaOpts)
+		pProxy := s.Schema.Properties[name]
+		schemaOpts := SchemaOpts{
+			Ignores: s.GetIgnoresForNested(name),
+		}
+
+		pSchema, err := BuildSchema(pProxy, schemaOpts, s.GlobalSchemaOpts)
 		if err != nil {
 			return schema.ElementType{}, s.NestSchemaError(err, name)
 		}

--- a/internal/mapper/oas/object.go
+++ b/internal/mapper/oas/object.go
@@ -14,6 +14,7 @@ func (s *OASSchema) BuildObjectElementType() (schema.ElementType, *SchemaError) 
 	// Guarantee the order of processing
 	propertyNames := util.SortedKeys(s.Schema.Properties)
 	for _, name := range propertyNames {
+
 		if s.IsPropertyIgnored(name) {
 			// TODO: produce a log?
 			continue

--- a/internal/mapper/oas/object.go
+++ b/internal/mapper/oas/object.go
@@ -16,7 +16,6 @@ func (s *OASSchema) BuildObjectElementType() (schema.ElementType, *SchemaError) 
 	for _, name := range propertyNames {
 
 		if s.IsPropertyIgnored(name) {
-			// TODO: produce a log?
 			continue
 		}
 

--- a/internal/mapper/provider_mapper.go
+++ b/internal/mapper/provider_mapper.go
@@ -56,7 +56,10 @@ func (m providerMapper) MapToIR(logger *slog.Logger) (*provider.Provider, error)
 func generateProviderSchema(logger *slog.Logger, exploredProvider explorer.Provider) (*provider.Schema, error) {
 	providerSchema := &provider.Schema{}
 
-	s, err := oas.BuildSchema(exploredProvider.SchemaProxy, oas.SchemaOpts{}, oas.GlobalSchemaOpts{})
+	schemaOpts := oas.SchemaOpts{
+		Ignores: exploredProvider.Ignores,
+	}
+	s, err := oas.BuildSchema(exploredProvider.SchemaProxy, schemaOpts, oas.GlobalSchemaOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mapper/provider_mapper_test.go
+++ b/internal/mapper/provider_mapper_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 )
 
-// TODO: add tests for error handling/skipping bad data sources
-
 func TestProviderMapper_basic(t *testing.T) {
 	t.Parallel()
 
@@ -93,6 +91,149 @@ func TestProviderMapper_basic(t *testing.T) {
 								OptionalRequired: schema.Required,
 								Description:      pointer("hey this is a string, required!"),
 								Sensitive:        pointer(true),
+							},
+						},
+					},
+				},
+			},
+		},
+		"provider with schema - ignores": {
+			exploredProvider: explorer.Provider{
+				Name: "example",
+				Ignores: []string{
+					"bool_prop",
+					"nested_obj.bool_prop",
+					"nested_array.deep_nested_bool",
+					"nested_map.deep_nested_bool",
+				},
+				SchemaProxy: base.CreateSchemaProxy(&base.Schema{
+					Type: []string{"object"},
+					Properties: map[string]*base.SchemaProxy{
+						"bool_prop": base.CreateSchemaProxy(&base.Schema{
+							Type:        []string{"boolean"},
+							Description: "This boolean is going to be ignored!",
+						}),
+						"number_prop": base.CreateSchemaProxy(&base.Schema{
+							Type:        []string{"number"},
+							Description: "hey this is a number!",
+						}),
+						"nested_obj": base.CreateSchemaProxy(&base.Schema{
+							Type: []string{"object"},
+							Properties: map[string]*base.SchemaProxy{
+								"bool_prop": base.CreateSchemaProxy(&base.Schema{
+									Type:        []string{"boolean"},
+									Description: "This boolean is going to be ignored!",
+								}),
+								"string_prop": base.CreateSchemaProxy(&base.Schema{
+									Type:        []string{"string"},
+									Description: "hey this is a string!",
+								}),
+							},
+						}),
+						"nested_array": base.CreateSchemaProxy(&base.Schema{
+							Type:        []string{"array"},
+							Description: "hey this is an array!",
+							Items: &base.DynamicValue[*base.SchemaProxy, bool]{
+								A: base.CreateSchemaProxy(&base.Schema{
+									Type: []string{"array"},
+									Items: &base.DynamicValue[*base.SchemaProxy, bool]{
+										A: base.CreateSchemaProxy(&base.Schema{
+											Type: []string{"object"},
+											Properties: map[string]*base.SchemaProxy{
+												"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
+													Type: []string{"boolean"},
+												}),
+												"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
+													Type: []string{"integer"},
+												}),
+											},
+										}),
+									},
+								}),
+							},
+						}),
+						"nested_map": base.CreateSchemaProxy(&base.Schema{
+							Type:        []string{"object"},
+							Description: "hey this is a map!",
+							AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
+								Type: []string{"object"},
+								Properties: map[string]*base.SchemaProxy{
+									"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"boolean"},
+									}),
+									"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"integer"},
+										Description: "hey this is an int64!",
+									}),
+								},
+							}),
+						}),
+					},
+				}),
+			},
+			want: &provider.Provider{
+				Name: "example",
+				Schema: &provider.Schema{
+					Attributes: provider.Attributes{
+						{
+							Name: "nested_array",
+							List: &provider.ListAttribute{
+								OptionalRequired: schema.Optional,
+								Description:      pointer("hey this is an array!"),
+								ElementType: schema.ElementType{
+									List: &schema.ListType{
+										ElementType: schema.ElementType{
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:  "deep_nested_int64",
+														Int64: &schema.Int64Type{},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "nested_map",
+							MapNested: &provider.MapNestedAttribute{
+								OptionalRequired: schema.Optional,
+								Description:      pointer("hey this is a map!"),
+								NestedObject: provider.NestedAttributeObject{
+									Attributes: []provider.Attribute{
+										{
+											Name: "deep_nested_int64",
+											Int64: &provider.Int64Attribute{
+												OptionalRequired: schema.Optional,
+												Description:      pointer("hey this is an int64!"),
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "nested_obj",
+							SingleNested: &provider.SingleNestedAttribute{
+								OptionalRequired: schema.Optional,
+								Attributes: []provider.Attribute{
+									{
+										Name: "string_prop",
+										String: &provider.StringAttribute{
+											OptionalRequired: schema.Optional,
+											Description:      pointer("hey this is a string!"),
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "number_prop",
+							Number: &provider.NumberAttribute{
+								OptionalRequired: schema.Optional,
+								Description:      pointer("hey this is a number!"),
 							},
 						},
 					},

--- a/internal/mapper/resource_mapper.go
+++ b/internal/mapper/resource_mapper.go
@@ -168,7 +168,6 @@ func generateResourceSchema(logger *slog.Logger, explorerResource explorer.Resou
 			}
 
 			if s.IsPropertyIgnored(paramName) {
-				// TODO: produce a log?
 				continue
 			}
 

--- a/internal/mapper/resource_mapper.go
+++ b/internal/mapper/resource_mapper.go
@@ -69,7 +69,11 @@ func generateResourceSchema(logger *slog.Logger, explorerResource explorer.Resou
 	// Create Request Body (required)
 	// ********************
 	logger.Debug("searching for create operation request body")
-	createRequestSchema, err := oas.BuildSchemaFromRequest(explorerResource.CreateOp, oas.SchemaOpts{}, oas.GlobalSchemaOpts{})
+
+	schemaOpts := oas.SchemaOpts{
+		Ignores: explorerResource.SchemaOptions.Ignores,
+	}
+	createRequestSchema, err := oas.BuildSchemaFromRequest(explorerResource.CreateOp, schemaOpts, oas.GlobalSchemaOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +86,15 @@ func generateResourceSchema(logger *slog.Logger, explorerResource explorer.Resou
 	// Create Response Body (optional)
 	// *********************
 	logger.Debug("searching for create operation response body")
+
 	createResponseAttributes := attrmapper.ResourceAttributes{}
-	createResponseSchema, err := oas.BuildSchemaFromResponse(explorerResource.CreateOp, oas.SchemaOpts{}, oas.GlobalSchemaOpts{OverrideComputability: schema.Computed})
+	schemaOpts = oas.SchemaOpts{
+		Ignores: explorerResource.SchemaOptions.Ignores,
+	}
+	globalSchemaOpts := oas.GlobalSchemaOpts{
+		OverrideComputability: schema.Computed,
+	}
+	createResponseSchema, err := oas.BuildSchemaFromResponse(explorerResource.CreateOp, schemaOpts, globalSchemaOpts)
 	if err != nil {
 		if errors.Is(err, oas.ErrSchemaNotFound) {
 			// Demote log to INFO if there was no schema found
@@ -102,8 +113,16 @@ func generateResourceSchema(logger *slog.Logger, explorerResource explorer.Resou
 	// READ Response Body (optional)
 	// *******************
 	logger.Debug("searching for read operation response body")
+
 	readResponseAttributes := attrmapper.ResourceAttributes{}
-	readResponseSchema, err := oas.BuildSchemaFromResponse(explorerResource.ReadOp, oas.SchemaOpts{}, oas.GlobalSchemaOpts{OverrideComputability: schema.Computed})
+
+	schemaOpts = oas.SchemaOpts{
+		Ignores: explorerResource.SchemaOptions.Ignores,
+	}
+	globalSchemaOpts = oas.GlobalSchemaOpts{
+		OverrideComputability: schema.Computed,
+	}
+	readResponseSchema, err := oas.BuildSchemaFromResponse(explorerResource.ReadOp, schemaOpts, globalSchemaOpts)
 	if err != nil {
 		if errors.Is(err, oas.ErrSchemaNotFound) {
 			// Demote log to INFO if there was no schema found
@@ -129,7 +148,10 @@ func generateResourceSchema(logger *slog.Logger, explorerResource explorer.Resou
 			}
 
 			pLogger := logger.With("param", param.Name)
-			schemaOpts := oas.SchemaOpts{OverrideDescription: param.Description}
+			schemaOpts := oas.SchemaOpts{
+				Ignores:             explorerResource.SchemaOptions.Ignores,
+				OverrideDescription: param.Description,
+			}
 			globalSchemaOpts := oas.GlobalSchemaOpts{OverrideComputability: schema.ComputedOptional}
 
 			s, schemaErr := oas.BuildSchema(param.Schema, schemaOpts, globalSchemaOpts)
@@ -143,6 +165,11 @@ func generateResourceSchema(logger *slog.Logger, explorerResource explorer.Resou
 			if aliasedName, ok := explorerResource.SchemaOptions.AttributeOptions.Aliases[param.Name]; ok {
 				pLogger = pLogger.With("param_alias", aliasedName)
 				paramName = aliasedName
+			}
+
+			if s.IsPropertyIgnored(paramName) {
+				// TODO: produce a log?
+				continue
 			}
 
 			parameterAttribute, schemaErr := s.BuildResourceAttribute(paramName, schema.ComputedOptional)


### PR DESCRIPTION
Closes #81 

This PR introduces new `schema.ignores` configuration options to the generator config to skip the mapping process for specific attributes. In the current implementation you can skip the mapping for ALL schemas (request, response, parameters, etc.), but not a single schema only (maybe a future request).

This enables incompatible schemas to ignore attributes that might not be supported, and can be done at any level of nesting, as shown below:

```yaml
data_sources:
  gists:
    read:
      path: /gists/{gist_id}
      method: GET
    schema:
      ignores:
        - fork_of.forks
        - fork_of.history
        - fork_of.files.language
        - forks.user.plan.collaborators
```

Documentation for this PR: https://github.com/hashicorp/terraform-docs-common/pull/490