### PR TITLE
Fix map handling with `allOf`/`oneOf` + upgrade `pb33f/libopenapi`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20231213-145019.yaml
+++ b/.changes/unreleased/BUG FIXES-20231213-145019.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: Fixed a bug where schemas that used `additionalProperties` with schema composition
+  (allOf/anyOf/oneOf) would return an empty single nested attribute. Will now return
+  map or map nested attribute.
+time: 2023-12-13T14:50:19.121128-05:00
+custom:
+  Issue: "100"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-codegen-spec v0.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mitchellh/cli v1.1.5
-	github.com/pb33f/libopenapi v0.11.0
+	github.com/pb33f/libopenapi v0.13.22
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -35,7 +35,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/sync v0.3.0 // indirect
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
+	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.11.0 h1:xhFWajHaTVXD5+hh7LHY7kVBDVEVMSO509NFs6SOiu4=
-github.com/pb33f/libopenapi v0.11.0/go.mod h1:s8uj6S0DjWrwZVj20ianJBz+MMjHAbeeRYNyo9ird74=
+github.com/pb33f/libopenapi v0.13.22 h1:QivxHLf+ZaYl2mFivUFkKZ7315mtYMipaQP5zp0U1H4=
+github.com/pb33f/libopenapi v0.13.22/go.mod h1:Lv2eEtsAtbRFlF8hjH82L8SIGoUNgemMVoKoB6A9THk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -148,8 +148,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -168,8 +168,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/pb33f/libopenapi"
-	"github.com/pb33f/libopenapi/resolver"
+	"github.com/pb33f/libopenapi/index"
 )
 
 type GenerateCommand struct {
@@ -133,7 +133,7 @@ func (cmd *GenerateCommand) runInternal(logger *slog.Logger) error {
 	// 4. Log circular references as warnings and fail on any other model building errors
 	var errResult error
 	for _, err := range errs {
-		if rslvErr, ok := err.(*resolver.ResolvingError); ok {
+		if rslvErr, ok := err.(*index.ResolvingError); ok {
 			logger.Warn(
 				"circular reference found in OpenAPI spec",
 				"circular_ref", rslvErr.CircularReference.GenerateJourneyPath())

--- a/internal/cmd/testdata/edgecase/openapi_spec.yml
+++ b/internal/cmd/testdata/edgecase/openapi_spec.yml
@@ -78,6 +78,9 @@ paths:
                   type: object
                   additionalProperties:
                     type: string
+                map_stringified:
+                  $ref: "#/components/schemas/map_allof_oneof_stringified"
+
   /set_test:
     get:
       summary: Test for SetNested attributes and Set attributes in a data source
@@ -213,3 +216,13 @@ components:
           bool_prop:
             description: Bool inside a map!
             type: boolean
+    map_allof_oneof_stringified:
+      description: This is a map with a stringifed value
+      type: object
+      additionalProperties:
+        allOf:
+        - $ref: "#/components/schemas/stringable_number"
+    stringable_number:
+      oneOf:
+      - type: string
+      - type: number

--- a/internal/cmd/testdata/edgecase/openapi_spec.yml
+++ b/internal/cmd/testdata/edgecase/openapi_spec.yml
@@ -73,6 +73,8 @@ paths:
               properties:
                 mapnested_prop:
                   $ref: "#/components/schemas/mapnested_schema"
+                mapnested_nullable:
+                  $ref: "#/components/schemas/mapnested_allof_oneof_nullable"
                 map_prop:
                   description: This is a map of strings
                   type: object
@@ -216,6 +218,12 @@ components:
           bool_prop:
             description: Bool inside a map!
             type: boolean
+    mapnested_allof_oneof_nullable:
+      description: This is a map with a nullable object
+      type: object
+      additionalProperties:
+        allOf:
+        - $ref: "#/components/schemas/nullable_object"
     map_allof_oneof_stringified:
       description: This is a map with a stringifed value
       type: object
@@ -226,3 +234,17 @@ components:
       oneOf:
       - type: string
       - type: number
+    nullable_object:
+      oneOf:
+      - type: object
+        required:
+        - string_prop
+        - bool_prop
+        properties:
+          string_prop:
+            description: String inside a map!
+            type: string
+          bool_prop:
+            description: Bool inside a map!
+            type: boolean
+      - type: "null"

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -290,6 +290,31 @@
 						}
 					},
 					{
+						"name": "mapnested_nullable",
+						"map_nested": {
+							"computed_optional_required": "computed_optional",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "bool_prop",
+										"bool": {
+											"computed_optional_required": "required",
+											"description": "Bool inside a map!"
+										}
+									},
+									{
+										"name": "string_prop",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "String inside a map!"
+										}
+									}
+								]
+							},
+							"description": "This is a map with a nullable object"
+						}
+					},
+					{
 						"name": "mapnested_prop",
 						"map_nested": {
 							"computed_optional_required": "required",

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -280,6 +280,13 @@
 						}
 					},
 					{
+						"name": "map_stringified",
+						"single_nested": {
+							"computed_optional_required": "computed_optional",
+							"description": "This is a map with a stringifed value"
+						}
+					},
+					{
 						"name": "mapnested_prop",
 						"map_nested": {
 							"computed_optional_required": "required",

--- a/internal/cmd/testdata/edgecase/provider_code_spec.json
+++ b/internal/cmd/testdata/edgecase/provider_code_spec.json
@@ -281,8 +281,11 @@
 					},
 					{
 						"name": "map_stringified",
-						"single_nested": {
+						"map": {
 							"computed_optional_required": "computed_optional",
+							"element_type": {
+								"string": {}
+							},
 							"description": "This is a map with a stringifed value"
 						}
 					},

--- a/internal/cmd/testdata/kubernetes/provider_code_spec.json
+++ b/internal/cmd/testdata/kubernetes/provider_code_spec.json
@@ -2540,15 +2540,21 @@
 																					},
 																					{
 																						"name": "limits",
-																						"single_nested": {
+																						"map": {
 																							"computed_optional_required": "computed_optional",
+																							"element_type": {
+																								"string": {}
+																							},
 																							"description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																						}
 																					},
 																					{
 																						"name": "requests",
-																						"single_nested": {
+																						"map": {
 																							"computed_optional_required": "computed_optional",
+																							"element_type": {
+																								"string": {}
+																							},
 																							"description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																						}
 																					}
@@ -4146,15 +4152,21 @@
 																					},
 																					{
 																						"name": "limits",
-																						"single_nested": {
+																						"map": {
 																							"computed_optional_required": "computed_optional",
+																							"element_type": {
+																								"string": {}
+																							},
 																							"description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																						}
 																					},
 																					{
 																						"name": "requests",
-																						"single_nested": {
+																						"map": {
 																							"computed_optional_required": "computed_optional",
+																							"element_type": {
+																								"string": {}
+																							},
 																							"description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																						}
 																					}
@@ -5773,15 +5785,21 @@
 																					},
 																					{
 																						"name": "limits",
-																						"single_nested": {
+																						"map": {
 																							"computed_optional_required": "computed_optional",
+																							"element_type": {
+																								"string": {}
+																							},
 																							"description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																						}
 																					},
 																					{
 																						"name": "requests",
-																						"single_nested": {
+																						"map": {
 																							"computed_optional_required": "computed_optional",
+																							"element_type": {
+																								"string": {}
+																							},
 																							"description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																						}
 																					}
@@ -6345,8 +6363,11 @@
 														},
 														{
 															"name": "overhead",
-															"single_nested": {
+															"map": {
 																"computed_optional_required": "computed_optional",
+																"element_type": {
+																	"string": {}
+																},
 																"description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md"
 															}
 														},
@@ -7729,15 +7750,21 @@
 																													"attributes": [
 																														{
 																															"name": "limits",
-																															"single_nested": {
+																															"map": {
 																																"computed_optional_required": "computed_optional",
+																																"element_type": {
+																																	"string": {}
+																																},
 																																"description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																															}
 																														},
 																														{
 																															"name": "requests",
-																															"single_nested": {
+																															"map": {
 																																"computed_optional_required": "computed_optional",
+																																"element_type": {
+																																	"string": {}
+																																},
 																																"description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
 																															}
 																														}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pb33f/libopenapi/index"
 	"gopkg.in/yaml.v3"
 )
 
@@ -137,11 +136,6 @@ func (p Provider) Validate() error {
 
 	if p.Name == "" {
 		result = errors.Join(result, errors.New("must have a 'name' property"))
-	}
-
-	// All schema refs must be a local, file, or http resolve type
-	if p.SchemaRef != "" && index.DetermineReferenceResolveType(p.SchemaRef) < 0 {
-		result = errors.Join(result, errors.New("'schema_ref' must be a valid JSON schema reference"))
 	}
 
 	for _, ignore := range p.Ignores {

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -213,19 +213,6 @@ func TestParseConfig_Invalid(t *testing.T) {
 			input:            ``,
 			expectedErrRegex: `provider must have a 'name' property`,
 		},
-		"provider - invalid schema_ref - not resolvable": {
-			input: `
-provider:
-  name: example
-  schema_ref: thisaintvalid
-
-data_sources:
-  thing_one:
-    read:
-      path: /example/path/to/thing/{id}
-      method: GET`,
-			expectedErrRegex: `provider 'schema_ref' must be a valid JSON schema reference`,
-		},
 		"provider - invalid ignore item": {
 			input: `
 provider:

--- a/internal/explorer/config_explorer.go
+++ b/internal/explorer/config_explorer.go
@@ -4,6 +4,7 @@
 package explorer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -157,7 +158,7 @@ func extractSchemaProxy(document high.Document, componentRef string) (*highbase.
 	}
 
 	// populate low-level schema, using root document.Index for resolving
-	err = lowSchema.Build(indexRef.Node, document.Index)
+	err = lowSchema.Build(context.Background(), indexRef.Node, document.Index)
 	if err != nil {
 		return nil, fmt.Errorf("error populating low-level schema: %w", err)
 	}

--- a/internal/mapper/datasource_mapper_test.go
+++ b/internal/mapper/datasource_mapper_test.go
@@ -722,18 +722,20 @@ func TestDataSourceMapper_basic_merges(t *testing.T) {
 					"nested_map": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey this is a map!",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type: []string{"object"},
-							Properties: map[string]*base.SchemaProxy{
-								"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"boolean"},
-								}),
-								"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"integer"},
-									Description: "hey this is an int64!",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type: []string{"object"},
+								Properties: map[string]*base.SchemaProxy{
+									"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"boolean"},
+									}),
+									"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"integer"},
+										Description: "hey this is an int64!",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			}),

--- a/internal/mapper/oas/collection_test.go
+++ b/internal/mapper/oas/collection_test.go
@@ -562,19 +562,21 @@ func TestBuildCollectionResource(t *testing.T) {
 						Items: &base.DynamicValue[*base.SchemaProxy, bool]{
 							A: base.CreateSchemaProxy(&base.Schema{
 								Type: []string{"object"},
-								AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"object"},
-									Properties: map[string]*base.SchemaProxy{
-										"nested_boolean": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"boolean"},
-											Description: "this won't be added, since it will map to element type",
-										}),
-										"nested_string": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"string"},
-											Description: "this won't be added, since it will map to element type",
-										}),
-									},
-								}),
+								AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+									A: base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"object"},
+										Properties: map[string]*base.SchemaProxy{
+											"nested_boolean": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"boolean"},
+												Description: "this won't be added, since it will map to element type",
+											}),
+											"nested_string": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"string"},
+												Description: "this won't be added, since it will map to element type",
+											}),
+										},
+									}),
+								},
 							}),
 						},
 					}),
@@ -585,21 +587,23 @@ func TestBuildCollectionResource(t *testing.T) {
 						Items: &base.DynamicValue[*base.SchemaProxy, bool]{
 							A: base.CreateSchemaProxy(&base.Schema{
 								Type: []string{"object"},
-								AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"object"},
-									Properties: map[string]*base.SchemaProxy{
-										"nested_float64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"number"},
-											Format:      "double",
-											Description: "this won't be added, since it will map to element type",
-										}),
-										"nested_int64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"integer"},
-											Format:      "int64",
-											Description: "this won't be added, since it will map to element type",
-										}),
-									},
-								}),
+								AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+									A: base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"object"},
+										Properties: map[string]*base.SchemaProxy{
+											"nested_float64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"number"},
+												Format:      "double",
+												Description: "this won't be added, since it will map to element type",
+											}),
+											"nested_int64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"integer"},
+												Format:      "int64",
+												Description: "this won't be added, since it will map to element type",
+											}),
+										},
+									}),
+								},
 							}),
 						},
 					}),
@@ -1221,19 +1225,21 @@ func TestBuildCollectionDataSource(t *testing.T) {
 						Items: &base.DynamicValue[*base.SchemaProxy, bool]{
 							A: base.CreateSchemaProxy(&base.Schema{
 								Type: []string{"object"},
-								AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"object"},
-									Properties: map[string]*base.SchemaProxy{
-										"nested_boolean": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"boolean"},
-											Description: "this won't be added, since it will map to element type",
-										}),
-										"nested_string": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"string"},
-											Description: "this won't be added, since it will map to element type",
-										}),
-									},
-								}),
+								AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+									A: base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"object"},
+										Properties: map[string]*base.SchemaProxy{
+											"nested_boolean": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"boolean"},
+												Description: "this won't be added, since it will map to element type",
+											}),
+											"nested_string": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"string"},
+												Description: "this won't be added, since it will map to element type",
+											}),
+										},
+									}),
+								},
 							}),
 						},
 					}),
@@ -1244,21 +1250,23 @@ func TestBuildCollectionDataSource(t *testing.T) {
 						Items: &base.DynamicValue[*base.SchemaProxy, bool]{
 							A: base.CreateSchemaProxy(&base.Schema{
 								Type: []string{"object"},
-								AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"object"},
-									Properties: map[string]*base.SchemaProxy{
-										"nested_float64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"number"},
-											Format:      "double",
-											Description: "this won't be added, since it will map to element type",
-										}),
-										"nested_int64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"integer"},
-											Format:      "int64",
-											Description: "this won't be added, since it will map to element type",
-										}),
-									},
-								}),
+								AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+									A: base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"object"},
+										Properties: map[string]*base.SchemaProxy{
+											"nested_float64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"number"},
+												Format:      "double",
+												Description: "this won't be added, since it will map to element type",
+											}),
+											"nested_int64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"integer"},
+												Format:      "int64",
+												Description: "this won't be added, since it will map to element type",
+											}),
+										},
+									}),
+								},
 							}),
 						},
 					}),
@@ -1880,19 +1888,21 @@ func TestBuildCollectionProvider(t *testing.T) {
 						Items: &base.DynamicValue[*base.SchemaProxy, bool]{
 							A: base.CreateSchemaProxy(&base.Schema{
 								Type: []string{"object"},
-								AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"object"},
-									Properties: map[string]*base.SchemaProxy{
-										"nested_boolean": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"boolean"},
-											Description: "this won't be added, since it will map to element type",
-										}),
-										"nested_string": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"string"},
-											Description: "this won't be added, since it will map to element type",
-										}),
-									},
-								}),
+								AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+									A: base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"object"},
+										Properties: map[string]*base.SchemaProxy{
+											"nested_boolean": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"boolean"},
+												Description: "this won't be added, since it will map to element type",
+											}),
+											"nested_string": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"string"},
+												Description: "this won't be added, since it will map to element type",
+											}),
+										},
+									}),
+								},
 							}),
 						},
 					}),
@@ -1903,21 +1913,23 @@ func TestBuildCollectionProvider(t *testing.T) {
 						Items: &base.DynamicValue[*base.SchemaProxy, bool]{
 							A: base.CreateSchemaProxy(&base.Schema{
 								Type: []string{"object"},
-								AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"object"},
-									Properties: map[string]*base.SchemaProxy{
-										"nested_float64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"number"},
-											Format:      "double",
-											Description: "this won't be added, since it will map to element type",
-										}),
-										"nested_int64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"integer"},
-											Format:      "int64",
-											Description: "this won't be added, since it will map to element type",
-										}),
-									},
-								}),
+								AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+									A: base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"object"},
+										Properties: map[string]*base.SchemaProxy{
+											"nested_float64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"number"},
+												Format:      "double",
+												Description: "this won't be added, since it will map to element type",
+											}),
+											"nested_int64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"integer"},
+												Format:      "int64",
+												Description: "this won't be added, since it will map to element type",
+											}),
+										},
+									}),
+								},
 							}),
 						},
 					}),

--- a/internal/mapper/oas/map.go
+++ b/internal/mapper/oas/map.go
@@ -4,7 +4,7 @@
 package oas
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-codegen-openapi/internal/mapper/attrmapper"
 	"github.com/hashicorp/terraform-plugin-codegen-openapi/internal/mapper/frameworkvalidators"
@@ -13,21 +13,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
-	"github.com/pb33f/libopenapi/datamodel/high/base"
 )
 
 func (s *OASSchema) BuildMapResource(name string, computability schema.ComputedOptionalRequired) (attrmapper.ResourceAttribute, *SchemaError) {
 	// Maps are detected as `type: object`, with an `additionalProperties` field that is a schema. `additionalProperties` can
 	// also be a boolean (which we should ignore and map to an SingleNestedAttribute), so calling functions should call s.IsMap() first.
-	mapSchemaProxy, ok := s.Schema.AdditionalProperties.(*base.SchemaProxy)
-	if !ok {
-		return nil, s.SchemaErrorFromProperty(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), name)
+	if !s.IsMap() {
+		return nil, s.SchemaErrorFromProperty(errors.New("invalid map, additionalProperties doesn't have a valid schema"), name)
 	}
 
 	schemaOpts := SchemaOpts{
 		Ignores: s.SchemaOpts.Ignores,
 	}
-	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
+	mapSchema, err := BuildSchema(s.Schema.AdditionalProperties.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -81,15 +79,14 @@ func (s *OASSchema) BuildMapResource(name string, computability schema.ComputedO
 func (s *OASSchema) BuildMapDataSource(name string, computability schema.ComputedOptionalRequired) (attrmapper.DataSourceAttribute, *SchemaError) {
 	// Maps are detected as `type: object`, with an `additionalProperties` field that is a schema. `additionalProperties` can
 	// also be a boolean (which we should ignore and map to an SingleNestedAttribute), so calling functions should call s.IsMap() first.
-	mapSchemaProxy, ok := s.Schema.AdditionalProperties.(*base.SchemaProxy)
-	if !ok {
-		return nil, s.SchemaErrorFromProperty(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), name)
+	if !s.IsMap() {
+		return nil, s.SchemaErrorFromProperty(errors.New("invalid map, additionalProperties doesn't have a valid schema"), name)
 	}
 
 	schemaOpts := SchemaOpts{
 		Ignores: s.SchemaOpts.Ignores,
 	}
-	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
+	mapSchema, err := BuildSchema(s.Schema.AdditionalProperties.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -144,15 +141,14 @@ func (s *OASSchema) BuildMapDataSource(name string, computability schema.Compute
 func (s *OASSchema) BuildMapProvider(name string, optionalOrRequired schema.OptionalRequired) (attrmapper.ProviderAttribute, *SchemaError) {
 	// Maps are detected as `type: object`, with an `additionalProperties` field that is a schema. `additionalProperties` can
 	// also be a boolean (which we should ignore and map to an SingleNestedAttribute), so calling functions should call s.IsMap() first.
-	mapSchemaProxy, ok := s.Schema.AdditionalProperties.(*base.SchemaProxy)
-	if !ok {
-		return nil, s.SchemaErrorFromProperty(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), name)
+	if !s.IsMap() {
+		return nil, s.SchemaErrorFromProperty(errors.New("invalid map, additionalProperties doesn't have a valid schema"), name)
 	}
 
 	schemaOpts := SchemaOpts{
 		Ignores: s.SchemaOpts.Ignores,
 	}
-	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
+	mapSchema, err := BuildSchema(s.Schema.AdditionalProperties.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return nil, s.NestSchemaError(err, name)
 	}
@@ -201,15 +197,14 @@ func (s *OASSchema) BuildMapProvider(name string, optionalOrRequired schema.Opti
 func (s *OASSchema) BuildMapElementType() (schema.ElementType, *SchemaError) {
 	// Maps are detected as `type: object`, with an `additionalProperties` field that is a schema. `additionalProperties` can
 	// also be a boolean (which we should ignore and map to an ObjectType), so calling functions should call s.IsMap() first.
-	mapSchemaProxy, ok := s.Schema.AdditionalProperties.(*base.SchemaProxy)
-	if !ok {
-		return schema.ElementType{}, SchemaErrorFromNode(fmt.Errorf("invalid map schema, expected type *base.SchemaProxy, got: %T", s.Schema.AdditionalProperties), s.Schema, AdditionalProperties)
+	if !s.IsMap() {
+		return schema.ElementType{}, SchemaErrorFromNode(errors.New("invalid map, additionalProperties doesn't have a valid schema"), s.Schema, AdditionalProperties)
 	}
 
 	schemaOpts := SchemaOpts{
 		Ignores: s.SchemaOpts.Ignores,
 	}
-	mapSchema, err := BuildSchema(mapSchemaProxy, schemaOpts, s.GlobalSchemaOpts)
+	mapSchema, err := BuildSchema(s.Schema.AdditionalProperties.A, schemaOpts, s.GlobalSchemaOpts)
 	if err != nil {
 		return schema.ElementType{}, err
 	}

--- a/internal/mapper/oas/map_test.go
+++ b/internal/mapper/oas/map_test.go
@@ -33,34 +33,36 @@ func TestBuildMapResource(t *testing.T) {
 					"nested_map_prop": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map nested type.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_password_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_obj_prop": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"object"},
-									Required:    []string{"nested_int64_required"},
-									Description: "hey there! I'm a single nested object type.",
-									Properties: map[string]*base.SchemaProxy{
-										"nested_float64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"number"},
-											Format:      "double",
-											Description: "hey there! I'm a nested float64 type.",
-										}),
-										"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"integer"},
-											Format:      "int64",
-											Description: "hey there! I'm a nested int64 type, required.",
-										}),
-									},
-								}),
-								"nested_password_required": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"string"},
-									Format:      "password",
-									Description: "hey there! I'm a nested string type, required.",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_password_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_obj_prop": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"object"},
+										Required:    []string{"nested_int64_required"},
+										Description: "hey there! I'm a single nested object type.",
+										Properties: map[string]*base.SchemaProxy{
+											"nested_float64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"number"},
+												Format:      "double",
+												Description: "hey there! I'm a nested float64 type.",
+											}),
+											"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"integer"},
+												Format:      "int64",
+												Description: "hey there! I'm a nested int64 type, required.",
+											}),
+										},
+									}),
+									"nested_password_required": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"string"},
+										Format:      "password",
+										Description: "hey there! I'm a nested string type, required.",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -116,16 +118,18 @@ func TestBuildMapResource(t *testing.T) {
 					"nested_map_prop": base.CreateSchemaProxy(&base.Schema{
 						Type:       []string{"object"},
 						Deprecated: pointer(true),
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_int64_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-									Type:   []string{"integer"},
-									Format: "int64",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_int64_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+										Type:   []string{"integer"},
+										Format: "int64",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -157,16 +161,18 @@ func TestBuildMapResource(t *testing.T) {
 					"nested_map_prop_required": base.CreateSchemaProxy(&base.Schema{
 						Type:          []string{"object"},
 						MinProperties: pointer(int64(1)),
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_int64_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-									Type:   []string{"integer"},
-									Format: "int64",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_int64_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+										Type:   []string{"integer"},
+										Format: "int64",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -209,17 +215,21 @@ func TestBuildMapResource(t *testing.T) {
 					"map_with_floats": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map type with floats.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:   []string{"number"},
-							Format: "float",
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:   []string{"number"},
+								Format: "float",
+							}),
+						},
 					}),
 					"map_with_strings_required": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map type with strings, required.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type: []string{"string"},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type: []string{"string"},
+							}),
+						},
 					}),
 				},
 			},
@@ -282,34 +292,36 @@ func TestBuildMapDataSource(t *testing.T) {
 					"nested_map_prop": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map nested type.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_password_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_obj_prop": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"object"},
-									Required:    []string{"nested_int64_required"},
-									Description: "hey there! I'm a single nested object type.",
-									Properties: map[string]*base.SchemaProxy{
-										"nested_float64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"number"},
-											Format:      "double",
-											Description: "hey there! I'm a nested float64 type.",
-										}),
-										"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"integer"},
-											Format:      "int64",
-											Description: "hey there! I'm a nested int64 type, required.",
-										}),
-									},
-								}),
-								"nested_password_required": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"string"},
-									Format:      "password",
-									Description: "hey there! I'm a nested string type, required.",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_password_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_obj_prop": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"object"},
+										Required:    []string{"nested_int64_required"},
+										Description: "hey there! I'm a single nested object type.",
+										Properties: map[string]*base.SchemaProxy{
+											"nested_float64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"number"},
+												Format:      "double",
+												Description: "hey there! I'm a nested float64 type.",
+											}),
+											"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"integer"},
+												Format:      "int64",
+												Description: "hey there! I'm a nested int64 type, required.",
+											}),
+										},
+									}),
+									"nested_password_required": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"string"},
+										Format:      "password",
+										Description: "hey there! I'm a nested string type, required.",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -365,16 +377,18 @@ func TestBuildMapDataSource(t *testing.T) {
 					"nested_map_prop": base.CreateSchemaProxy(&base.Schema{
 						Type:       []string{"object"},
 						Deprecated: pointer(true),
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_int64_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-									Type:   []string{"integer"},
-									Format: "int64",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_int64_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+										Type:   []string{"integer"},
+										Format: "int64",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -406,16 +420,18 @@ func TestBuildMapDataSource(t *testing.T) {
 					"nested_map_prop_required": base.CreateSchemaProxy(&base.Schema{
 						Type:          []string{"object"},
 						MinProperties: pointer(int64(1)),
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_int64_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-									Type:   []string{"integer"},
-									Format: "int64",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_int64_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+										Type:   []string{"integer"},
+										Format: "int64",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -458,17 +474,21 @@ func TestBuildMapDataSource(t *testing.T) {
 					"map_with_floats": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map type with floats.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:   []string{"number"},
-							Format: "float",
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:   []string{"number"},
+								Format: "float",
+							}),
+						},
 					}),
 					"map_with_strings_required": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map type with strings, required.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type: []string{"string"},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type: []string{"string"},
+							}),
+						},
 					}),
 				},
 			},
@@ -531,34 +551,36 @@ func TestBuildMapProvider(t *testing.T) {
 					"nested_map_prop": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map nested type.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_password_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_obj_prop": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"object"},
-									Required:    []string{"nested_int64_required"},
-									Description: "hey there! I'm a single nested object type.",
-									Properties: map[string]*base.SchemaProxy{
-										"nested_float64": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"number"},
-											Format:      "double",
-											Description: "hey there! I'm a nested float64 type.",
-										}),
-										"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-											Type:        []string{"integer"},
-											Format:      "int64",
-											Description: "hey there! I'm a nested int64 type, required.",
-										}),
-									},
-								}),
-								"nested_password_required": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"string"},
-									Format:      "password",
-									Description: "hey there! I'm a nested string type, required.",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_password_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_obj_prop": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"object"},
+										Required:    []string{"nested_int64_required"},
+										Description: "hey there! I'm a single nested object type.",
+										Properties: map[string]*base.SchemaProxy{
+											"nested_float64": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"number"},
+												Format:      "double",
+												Description: "hey there! I'm a nested float64 type.",
+											}),
+											"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+												Type:        []string{"integer"},
+												Format:      "int64",
+												Description: "hey there! I'm a nested int64 type, required.",
+											}),
+										},
+									}),
+									"nested_password_required": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"string"},
+										Format:      "password",
+										Description: "hey there! I'm a nested string type, required.",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -614,16 +636,18 @@ func TestBuildMapProvider(t *testing.T) {
 					"nested_map_prop": base.CreateSchemaProxy(&base.Schema{
 						Type:       []string{"object"},
 						Deprecated: pointer(true),
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_int64_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-									Type:   []string{"integer"},
-									Format: "int64",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_int64_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+										Type:   []string{"integer"},
+										Format: "int64",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -655,16 +679,18 @@ func TestBuildMapProvider(t *testing.T) {
 					"nested_map_prop_required": base.CreateSchemaProxy(&base.Schema{
 						Type:          []string{"object"},
 						MinProperties: pointer(int64(1)),
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:     []string{"object"},
-							Required: []string{"nested_int64_required"},
-							Properties: map[string]*base.SchemaProxy{
-								"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
-									Type:   []string{"integer"},
-									Format: "int64",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:     []string{"object"},
+								Required: []string{"nested_int64_required"},
+								Properties: map[string]*base.SchemaProxy{
+									"nested_int64_required": base.CreateSchemaProxy(&base.Schema{
+										Type:   []string{"integer"},
+										Format: "int64",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			},
@@ -707,17 +733,21 @@ func TestBuildMapProvider(t *testing.T) {
 					"map_with_floats": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map type with floats.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type:   []string{"number"},
-							Format: "float",
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type:   []string{"number"},
+								Format: "float",
+							}),
+						},
 					}),
 					"map_with_strings_required": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey there! I'm a map type with strings, required.",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type: []string{"string"},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type: []string{"string"},
+							}),
+						},
 					}),
 				},
 			},

--- a/internal/mapper/oas/oas_schema.go
+++ b/internal/mapper/oas/oas_schema.go
@@ -53,8 +53,7 @@ type SchemaOpts struct {
 //
 // [JSON Schema - additionalProperties]: https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties
 func (s *OASSchema) IsMap() bool {
-	_, isMap := s.Schema.AdditionalProperties.(*base.SchemaProxy)
-	return isMap
+	return s.Schema.AdditionalProperties != nil && s.Schema.AdditionalProperties.IsA()
 }
 
 // SchemaErrorFromProperty is a helper function for creating an SchemaError struct for a property.

--- a/internal/mapper/oas/oas_schema.go
+++ b/internal/mapper/oas/oas_schema.go
@@ -48,8 +48,7 @@ type SchemaOpts struct {
 	OverrideDescription string
 }
 
-// IsMap will perform a type assertion on the `additionalProperties` field to determine if a map type
-// is appropriate (refer to [JSON Schema - additionalProperties]).
+// IsMap checks the `additionalProperties` field to determine if a map type is appropriate (refer to [JSON Schema - additionalProperties]).
 //
 // [JSON Schema - additionalProperties]: https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties
 func (s *OASSchema) IsMap() bool {

--- a/internal/mapper/provider_mapper_test.go
+++ b/internal/mapper/provider_mapper_test.go
@@ -155,18 +155,20 @@ func TestProviderMapper_basic(t *testing.T) {
 						"nested_map": base.CreateSchemaProxy(&base.Schema{
 							Type:        []string{"object"},
 							Description: "hey this is a map!",
-							AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-								Type: []string{"object"},
-								Properties: map[string]*base.SchemaProxy{
-									"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
-										Type: []string{"boolean"},
-									}),
-									"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
-										Type:        []string{"integer"},
-										Description: "hey this is an int64!",
-									}),
-								},
-							}),
+							AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+								A: base.CreateSchemaProxy(&base.Schema{
+									Type: []string{"object"},
+									Properties: map[string]*base.SchemaProxy{
+										"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
+											Type: []string{"boolean"},
+										}),
+										"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
+											Type:        []string{"integer"},
+											Description: "hey this is an int64!",
+										}),
+									},
+								}),
+							},
 						}),
 					},
 				}),

--- a/internal/mapper/resource_mapper_test.go
+++ b/internal/mapper/resource_mapper_test.go
@@ -865,18 +865,20 @@ func TestResourceMapper_basic_merges(t *testing.T) {
 					"nested_map": base.CreateSchemaProxy(&base.Schema{
 						Type:        []string{"object"},
 						Description: "hey this is a map!",
-						AdditionalProperties: base.CreateSchemaProxy(&base.Schema{
-							Type: []string{"object"},
-							Properties: map[string]*base.SchemaProxy{
-								"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
-									Type: []string{"boolean"},
-								}),
-								"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
-									Type:        []string{"integer"},
-									Description: "hey this is an int64!",
-								}),
-							},
-						}),
+						AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+							A: base.CreateSchemaProxy(&base.Schema{
+								Type: []string{"object"},
+								Properties: map[string]*base.SchemaProxy{
+									"deep_nested_bool": base.CreateSchemaProxy(&base.Schema{
+										Type: []string{"boolean"},
+									}),
+									"deep_nested_int64": base.CreateSchemaProxy(&base.Schema{
+										Type:        []string{"integer"},
+										Description: "hey this is an int64!",
+									}),
+								},
+							}),
+						},
 					}),
 				},
 			}),


### PR DESCRIPTION
Closes #100 

This bug was the result of a downstream bug in `pb33f/libopenapi`, where schema's with `additionalProperties` that utilized `allOf`, `anyOf`, or `oneOf` were not being unmarshaled properly. This resulted in the code generator incorrectly determining that a map was a single nested object with no attributes. This was fixed in https://github.com/pb33f/libopenapi/pull/180 and released in [`v0.12.0`](https://github.com/pb33f/libopenapi/releases/tag/v0.12.0)

This PR upgrades `pb33f/libopenapi`, which had some breaking changes to the structure of the code, but no major functional changes outside of the removal of one helper function, which I'll note below.