### PR TITLE
internal/cmd: Add kubernetes spec to the golden file tests

### DIFF
--- a/internal/cmd/generate_test.go
+++ b/internal/cmd/generate_test.go
@@ -41,6 +41,11 @@ func TestGenerate_WithConfig(t *testing.T) {
 			configPath:     "testdata/edgecase/generator_config.yml",
 			goldenFilePath: "testdata/edgecase/provider_code_spec.json",
 		},
+		"Kubernetes API": {
+			oasSpecPath:    "testdata/kubernetes/openapi_spec.json",
+			configPath:     "testdata/kubernetes/generator_config.yml",
+			goldenFilePath: "testdata/kubernetes/provider_code_spec.json",
+		},
 	}
 	for name, testCase := range testCases {
 		name, testCase := name, testCase


### PR DESCRIPTION
Noticed this from a different PR. This golden file needs to be validated in the test. It's already present in the makefile, this just makes sure that you run it. 😄 